### PR TITLE
fix(survey): Fix TypeError on survey creation page

### DIFF
--- a/02_dashboard/src/surveyCreation.js
+++ b/02_dashboard/src/surveyCreation.js
@@ -102,10 +102,12 @@ async function initializePage() {
         const periodEnd = params.get('periodEnd');
 
         if (surveyName) {
+            if (typeof surveyData.name !== 'object' || surveyData.name === null) surveyData.name = {};
             surveyData.name.ja = surveyName;
             document.getElementById('surveyName').value = surveyName;
         }
         if (displayTitle) {
+            if (typeof surveyData.displayTitle !== 'object' || surveyData.displayTitle === null) surveyData.displayTitle = {};
             surveyData.displayTitle.ja = displayTitle;
             document.getElementById('displayTitle').value = displayTitle;
         }


### PR DESCRIPTION
This PR fixes a `TypeError` that occurred on the survey creation page.

**Cause:**
The error was triggered when the page was loaded with URL query parameters from the new survey modal. The code attempted to set a property on `surveyData.name` and `surveyData.displayTitle`, but these could sometimes be strings instead of the expected objects, leading to the error.

**Fix:**
The `initializePage` function in `surveyCreation.js` has been updated to ensure that `surveyData.name` and `surveyData.displayTitle` are objects before any properties are set on them. This prevents the TypeError and makes the data handling more robust.

This fix is related to the feature implemented in Issue #37.