### PR TITLE
feat: ログイン後の遷移先を初回ログイン画面に変更

### DIFF
--- a/docs/画面推移図.md
+++ b/docs/画面推移図.md
@@ -25,8 +25,18 @@ graph TD
         end
     end
 
+    subgraph "初回ログイン (04_first-login)"
+        I[初回登録画面<br>(index.html)]
+    end
+
+    subgraph "管理画面 (03_admin)"
+        J[管理者TOP<br>(index.html)]
+    end
+
     %% 認証フロー
-    A -- ログイン成功 --> B
+    A -- "ログイン成功 (通常ユーザー)" --> B
+    A -- "ログイン成功 (新規ユーザー)" --> I
+    A -- "ログイン成功 (管理者)" --> J
     A -- "無料ではじめる" --> M1
     M1 -- "ログインはこちら" --> A
     B -- ログアウト --> A
@@ -56,6 +66,6 @@ graph TD
     %% スタイル定義
     classDef page fill:#e8f0fe,stroke:#3367d6,stroke-width:2px;
     classDef modal fill:#fce8e6,stroke:#d93025,stroke-width:2px;
-    class A,B,C,D,E,F,G,H page;
+    class A,B,C,D,E,F,G,H,I,J page;
     class M1,M2,M3,M4,M5 modal;
     class Sidebar fill:#e6f4ea,stroke:#1e8e3e,stroke-width:2px;

--- a/index.html
+++ b/index.html
@@ -984,6 +984,8 @@
             let targetUrl = resolveAppPath('02_dashboard/index.html'); // デフォルト
             if (userEmail === 'admin') {
               targetUrl = resolveAppPath('03_admin/index.html');
+            } else if (userEmail === 'new') {
+              targetUrl = resolveAppPath('04_first-login/index.html');
             }
             // 'user' またはその他の場合はデフォルトのURLを使用
             window.location.href = targetUrl;


### PR DESCRIPTION
Closes #64

## 概要
`new` ユーザーでログインした際の遷移先を、`02_dashboard/index.html` から `04_first-login/index.html` に変更しました。

## 変更点
- `index.html` のログインスクリプトを修正し、`new` ユーザー用のリダイレクト処理を追加しました。
- `docs/画面推移図.md` を更新し、新しい画面遷移フローを反映させました。

## 確認方法
1. ログイン画面で `new` と入力してログインします。
2. `04_first-login/index.html` に遷移することを確認します。
3. `user` や `admin` でログインした場合は、これまで通りの画面に遷移することを確認します。
