### PR TITLE
feat: enrich bizcard plan selection

### DIFF
--- a/02_dashboard/bizcardSettings.html
+++ b/02_dashboard/bizcardSettings.html
@@ -56,10 +56,16 @@
                         <div id="bizcardSettingsFields" class="space-y-6">
 
                             <!-- データ化項目プラン -->
-                            <div class="space-y-2">
-                                
-                                <div class="grid grid-cols-1 md:grid-cols-3 gap-4" id="dataConversionPlanSelection">
+                            <div class="space-y-4">
+                                <h2 class="text-on-surface text-xl font-bold">データ化項目プラン</h2>
+                                <p class="text-sm text-on-surface-variant">名刺データの読み取り範囲や課金方式をプランごとに選択できます。組織のワークフローにあわせて最適なプランをお選びください。</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4" id="dataConversionPlanSelection">
                                     <!-- Plan cards will be dynamically inserted here -->
+                                </div>
+                                <div class="space-y-1 text-xs leading-relaxed text-on-surface-variant" id="dataConversionPlanNotes">
+                                    <p>※ 名刺データ化プランの選択と見込み枚数の入力は必須項目です。未選択の場合は依頼を完了できません。</p>
+                                    <p>※ 請求は毎月末締め・翌月末払いでご案内します。表示料金は税抜金額で、別途消費税が加算されます。</p>
+                                    <p>※ 名刺データ化はOCRと有人チェックを組み合わせて実施します。手書きや特殊レイアウトの名刺は補正のため追加日数を頂く場合があります。</p>
                                 </div>
                             </div>
 

--- a/02_dashboard/src/bizcardSettings.js
+++ b/02_dashboard/src/bizcardSettings.js
@@ -12,10 +12,86 @@ import {
     renderEstimate,
     displayCouponResult,
     validateForm,
-    setSaveButtonLoading
+    setSaveButtonLoading,
+    renderDataConversionPlans
 } from './ui/bizcardSettingsRenderer.js';
 import { showToast } from './utils.js';
 import { showConfirmationModal } from './confirmationModal.js';
+
+const DATA_CONVERSION_PLANS = [
+    {
+        value: 'free',
+        title: { ja: '無料トライアル', en: 'Free Trial' },
+        price: { ja: '¥0', en: '¥0' },
+        priceNote: { ja: '月額・初期費用なし', en: 'No monthly or initial fee' },
+        badges: [
+            { text: { ja: '対象項目: 氏名 / 会社名 / メール', en: 'Fields: Name / Company / Email' }, tone: 'info' },
+            { text: { ja: '月間50枚まで', en: 'Up to 50 cards / month' }, tone: 'limit' }
+        ],
+        description: {
+            ja: '名刺データ化をまずは試したい方向け。OCRによる自動抽出のみ提供します。',
+            en: 'Entry plan with OCR-only extraction for teams trying the service.'
+        },
+        highlights: [
+            { ja: '納期目安: 3営業日', en: 'Turnaround: 3 business days' },
+            { ja: '納品形式: CSVダウンロード', en: 'Delivery: CSV download' }
+        ]
+    },
+    {
+        value: 'standard',
+        title: { ja: 'スタンダード', en: 'Standard' },
+        price: { ja: '¥5,000', en: '¥5,000' },
+        priceNote: { ja: '基本料金', en: 'Base charge' },
+        badges: [
+            { text: { ja: '対象項目: 氏名 / 会社名 / 部署 / 役職 / メール', en: 'Fields: Name / Company / Department / Title / Email' }, tone: 'info' },
+            { text: { ja: '月間300枚まで', en: 'Up to 300 cards / month' }, tone: 'limit' }
+        ],
+        description: {
+            ja: 'もっとも選ばれている標準プラン。有人によるダブルチェックで高精度なデータを納品します。',
+            en: 'Most popular plan with human double-checks for high accuracy.'
+        },
+        highlights: [
+            { ja: '納期目安: 2営業日', en: 'Turnaround: 2 business days' },
+            { ja: '納品形式: CSV / Excel', en: 'Delivery: CSV / Excel' }
+        ]
+    },
+    {
+        value: 'premium',
+        title: { ja: 'プレミアム', en: 'Premium' },
+        price: { ja: '¥12,000', en: '¥12,000' },
+        priceNote: { ja: '高度な名寄せ・重複排除込み', en: 'Includes advanced deduplication' },
+        badges: [
+            { text: { ja: '対象項目: スタンダード項目 + SNS・QR情報', en: 'Fields: Standard + Social / QR data' }, tone: 'info' },
+            { text: { ja: '月間1,000枚まで', en: 'Up to 1,000 cards / month' }, tone: 'limit' }
+        ],
+        description: {
+            ja: 'イベントや展示会で大量の名刺を扱う企業向け。CRM連携用の整形データを納品します。',
+            en: 'Ideal for events with high volume, delivering CRM-ready formatted data.'
+        },
+        highlights: [
+            { ja: '納期目安: 1営業日', en: 'Turnaround: 1 business day' },
+            { ja: '納品形式: CSV / Excel / Salesforce', en: 'Delivery: CSV / Excel / Salesforce' }
+        ]
+    },
+    {
+        value: 'enterprise',
+        title: { ja: 'エンタープライズ', en: 'Enterprise' },
+        price: { ja: '¥25,000〜', en: '¥25,000+' },
+        priceNote: { ja: 'ボリューム割引 & カスタム要件対応', en: 'Volume pricing & custom workflows' },
+        badges: [
+            { text: { ja: '対象項目: プレミアム項目 + カスタム項目', en: 'Fields: Premium + Custom fields' }, tone: 'info' },
+            { text: { ja: '月間無制限（個別見積り）', en: 'Unlimited (custom quote)' }, tone: 'limit' }
+        ],
+        description: {
+            ja: '専任オペレーターや機密保持契約など大規模運用に対応。ワークフロー連携も個別に設計します。',
+            en: 'Supports dedicated operators, NDAs, and bespoke workflow integrations.'
+        },
+        highlights: [
+            { ja: '納期目安: 個別スケジュール', en: 'Turnaround: Custom schedule' },
+            { ja: '納品形式: CRM / MAプラットフォーム連携', en: 'Delivery: CRM / MA platform integrations' }
+        ]
+    }
+];
 
 export function initBizcardSettings() {
     // --- DOM Element Cache ---
@@ -230,6 +306,12 @@ export function initBizcardSettings() {
         if(settingsFields) {
             settingsFields.classList.remove('hidden');
         }
+
+        if (!state.settings.dataConversionPlan && DATA_CONVERSION_PLANS.length > 0) {
+            state.settings.dataConversionPlan = DATA_CONVERSION_PLANS[0].value;
+        }
+
+        renderDataConversionPlans(DATA_CONVERSION_PLANS, state.settings.dataConversionPlan);
 
         const estimate = calculateEstimate(state.settings, state.appliedCoupon);
         renderEstimate(estimate);

--- a/02_dashboard/src/services/bizcardCalculator.js
+++ b/02_dashboard/src/services/bizcardCalculator.js
@@ -4,8 +4,10 @@
  */
 
 const PLAN_PRICES = {
-    standard: 500,
-    premium: 1000,
+    free: 0,
+    standard: 5000,
+    premium: 12000,
+    enterprise: 25000,
     custom: 0 // カスタムプランは別途計算
 };
 


### PR DESCRIPTION
## Summary
- add localized plan metadata and render logic for bizcard plan cards with visual highlighting
- expose required explanatory notes and pricing details directly in the template
- update calculator pricing tiers to align with the new plan lineup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3245bad008323ba583041536299ec