### PR TITLE
Fix wide layout handling on survey builder and thank-you settings pages

### DIFF
--- a/02_dashboard/surveyCreation.html
+++ b/02_dashboard/surveyCreation.html
@@ -61,23 +61,8 @@
       <div id="sidebar-placeholder"></div>
 
       <!-- Main Content -->
-      <main class="flex flex-1 flex-col py-8 px-4 sm:px-6 lg:px-8 relative">
-        <div id="outline-map-container" class="hidden lg:flex fixed right-0 top-16 h-[calc(100vh-64px)] w-72 flex-col bg-surface border-l border-outline-variant p-4 overflow-hidden z-40">
-  <div id="outline-map-scroll" class="flex-1 overflow-y-auto">
-    <div id="outline-map-list" class="space-y-2"></div>
-  </div>
-  <div id="outline-action-buttons" class="mt-4 space-y-2 hidden">
-    <button type="button" data-outline-action="preview" class="w-full inline-flex items-center justify-center gap-2 rounded-full border border-outline-variant px-4 py-2 text-sm font-semibold text-on-surface hover:bg-surface-variant transition-colors">
-      <span class="material-icons text-base">visibility</span>
-      <span>プレビュー表示</span>
-    </button>
-    <button type="button" data-outline-action="save" class="w-full inline-flex items-center justify-center gap-2 rounded-full bg-primary text-on-primary px-4 py-2 text-sm font-semibold shadow-sm hover:bg-primary-dark transition-colors">
-      <span class="material-icons text-base">save</span>
-      <span>アンケート保存</span>
-    </button>
-  </div>
-</div>
-        <div id="survey-content-area" class="flex flex-col w-full max-w-6xl mx-auto flex-1">
+      <main class="flex flex-1 flex-col py-8 px-4 sm:px-6 lg:px-8 lg:grid lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start lg:gap-6">
+        <div id="survey-content-area" class="flex flex-col w-full max-w-6xl mx-auto flex-1 lg:mx-0 lg:max-w-none lg:col-span-1">
           <!-- Breadcrumb -->
           <div id="breadcrumb-container" class="mb-4"></div>
 
@@ -202,6 +187,21 @@
             </div>
           </div>
         </div>
+        <div id="outline-map-container" class="hidden lg:flex lg:col-span-1 lg:sticky lg:top-16 h-[calc(100vh-64px)] w-72 flex-col bg-surface border border-outline-variant rounded-xl p-4 overflow-hidden">
+  <div id="outline-map-scroll" class="flex-1 overflow-y-auto">
+    <div id="outline-map-list" class="space-y-2"></div>
+  </div>
+  <div id="outline-action-buttons" class="mt-4 space-y-2 hidden">
+    <button type="button" data-outline-action="preview" class="w-full inline-flex items-center justify-center gap-2 rounded-full border border-outline-variant px-4 py-2 text-sm font-semibold text-on-surface hover:bg-surface-variant transition-colors">
+      <span class="material-icons text-base">visibility</span>
+      <span>プレビュー表示</span>
+    </button>
+    <button type="button" data-outline-action="save" class="w-full inline-flex items-center justify-center gap-2 rounded-full bg-primary text-on-primary px-4 py-2 text-sm font-semibold shadow-sm hover:bg-primary-dark transition-colors">
+      <span class="material-icons text-base">save</span>
+      <span>アンケート保存</span>
+    </button>
+  </div>
+</div>
       </main>
     </div>
 

--- a/02_dashboard/thankYouEmailSettings.html
+++ b/02_dashboard/thankYouEmailSettings.html
@@ -51,7 +51,7 @@
                 </div>
 
                 <!-- お礼メール設定フォーム -->
-                <div class="bg-surface p-6 rounded-xl space-y-6">
+                <div class="bg-surface p-6 rounded-xl space-y-6 xl:max-w-4xl 2xl:mx-auto">
                     <div class="flex items-center justify-between p-4 bg-surface-container rounded-lg shadow-sm">
                         <label for="thankYouEmailEnabledToggle" class="text-on-surface font-semibold text-lg">お礼メール送信</label>
                         <label class="relative inline-flex items-center cursor-pointer">


### PR DESCRIPTION
## Summary
- cap the thank-you email settings card width on very wide screens to keep copy readable
- refactor the survey creation layout into a responsive grid so the outline panel no longer overlaps the form on large viewports

## Testing
- not run (static HTML updates)

## Affected Paths
- 02_dashboard/thankYouEmailSettings.html
- 02_dashboard/surveyCreation.html

------
https://chatgpt.com/codex/tasks/task_e_68e61682c6108323bc9503f78538fdc1