### PR TITLE
feat: clarify data conversion plan deltas

### DIFF
--- a/02_dashboard/src/bizcardSettings.js
+++ b/02_dashboard/src/bizcardSettings.js
@@ -19,12 +19,120 @@ import {
 import { showToast } from './utils.js';
 import { showConfirmationModal } from './confirmationModal.js';
 
+const DATA_CONVERSION_FEATURES = {
+    basicFields: {
+        key: 'basic-fields',
+        text: {
+            ja: '対象項目: 氏名 / メールアドレス',
+            en: 'Fields: Name / Email'
+        }
+    },
+    monthlyLimit50: {
+        key: 'monthly-limit-50',
+        text: {
+            ja: '月間50枚まで',
+            en: 'Up to 50 cards / month'
+        }
+    },
+    turnaround6Days: {
+        key: 'turnaround-6-days',
+        text: {
+            ja: '納期目安: 6営業日',
+            en: 'Turnaround: 6 business days'
+        }
+    },
+    retention90Days: {
+        key: 'retention-90-days',
+        text: {
+            ja: 'データ保存期間: 90日間',
+            en: 'Data retention: 90 days'
+        }
+    },
+    extendedFields: {
+        key: 'extended-fields',
+        text: {
+            ja: '対象項目: 氏名 / メール / 会社名 / 部署 / 役職 / 郵便番号 / 住所 / 電話 / 携帯 / Webサイト',
+            en: 'Fields: Name / Email / Company / Department / Title / Zip / Address / Phone / Mobile / Website'
+        }
+    },
+    doubleCheck: {
+        key: 'double-check',
+        text: {
+            ja: '有人ダブルチェックで高精度',
+            en: 'High accuracy with human double-checks'
+        }
+    },
+    socialQrFields: {
+        key: 'social-qr-fields',
+        text: {
+            ja: 'SNS・QRコードなどの追加項目',
+            en: 'Includes social and QR data'
+        }
+    },
+    crmReadyData: {
+        key: 'crm-ready-data',
+        text: {
+            ja: 'CRM連携向けの整形データ',
+            en: 'CRM-ready formatted data'
+        }
+    },
+    sameDaySupport: {
+        key: 'same-day-support',
+        text: {
+            ja: '最短当日納品に対応',
+            en: 'Same-day delivery available'
+        }
+    },
+    unlimitedRetention: {
+        key: 'unlimited-retention',
+        text: {
+            ja: 'データ保存期間: 無期限',
+            en: 'Data retention: Unlimited'
+        }
+    }
+};
+
+const FREE_PLAN_BASE_FEATURES = [
+    DATA_CONVERSION_FEATURES.basicFields,
+    DATA_CONVERSION_FEATURES.monthlyLimit50
+];
+
+const FREE_PLAN_ADDITIONAL_FEATURES = [
+    DATA_CONVERSION_FEATURES.turnaround6Days,
+    DATA_CONVERSION_FEATURES.retention90Days
+];
+
+const STANDARD_PLAN_BASE_FEATURES = [
+    ...FREE_PLAN_BASE_FEATURES,
+    ...FREE_PLAN_ADDITIONAL_FEATURES
+];
+
+const STANDARD_PLAN_ADDITIONAL_FEATURES = [
+    DATA_CONVERSION_FEATURES.extendedFields,
+    DATA_CONVERSION_FEATURES.doubleCheck
+];
+
+const PREMIUM_PLAN_BASE_FEATURES = [
+    ...STANDARD_PLAN_BASE_FEATURES,
+    ...STANDARD_PLAN_ADDITIONAL_FEATURES
+];
+
+const PREMIUM_PLAN_ADDITIONAL_FEATURES = [
+    DATA_CONVERSION_FEATURES.socialQrFields,
+    DATA_CONVERSION_FEATURES.crmReadyData,
+    DATA_CONVERSION_FEATURES.sameDaySupport,
+    DATA_CONVERSION_FEATURES.unlimitedRetention
+];
+
 const DATA_CONVERSION_PLANS = [
     {
         value: 'free',
         title: { ja: 'お試しプラン', en: 'Trial Plan' },
         price: { ja: '¥50/枚', en: '¥50/card' },
         priceNote: { ja: '2項目対応（氏名・メールアドレス）', en: 'Includes 2 fields (Name & Email)' },
+        basePlanKey: null,
+        baseFeatures: [...FREE_PLAN_BASE_FEATURES],
+        additionalFeatures: [...FREE_PLAN_ADDITIONAL_FEATURES],
         badges: [
             { text: { ja: '対象項目: 氏名 / メールアドレス', en: 'Fields: Name / Email' }, tone: 'info' },
             { text: { ja: '月間50枚まで', en: 'Up to 50 cards / month' }, tone: 'limit' }
@@ -43,6 +151,9 @@ const DATA_CONVERSION_PLANS = [
         title: { ja: 'スタンダード', en: 'Standard' },
         price: { ja: '¥50/枚〜', en: '¥50/card〜' },
         priceNote: { ja: '10項目データ化（通常作業 @50円）', en: 'Up to 10 fields (Normal @¥50/card)' },
+        basePlanKey: 'free',
+        baseFeatures: [...STANDARD_PLAN_BASE_FEATURES],
+        additionalFeatures: [...STANDARD_PLAN_ADDITIONAL_FEATURES],
         badges: [
             { text: { ja: '対象項目: 氏名 / メール / 会社名 / 部署 / 役職 / 郵便番号 / 住所 / 電話 / 携帯 / Webサイト', en: 'Fields: Name / Email / Company / Department / Title / Zip / Address / Phone / Mobile / Website' }, tone: 'info' }
         ],
@@ -60,6 +171,9 @@ const DATA_CONVERSION_PLANS = [
         title: { ja: 'プレミアム', en: 'Premium' },
         price: { ja: '要お見積もり', en: 'Custom quote' },
         priceNote: { ja: '月額契約（個別見積り）', en: 'Monthly contract (custom quote)' },
+        basePlanKey: 'standard',
+        baseFeatures: [...PREMIUM_PLAN_BASE_FEATURES],
+        additionalFeatures: [...PREMIUM_PLAN_ADDITIONAL_FEATURES],
         badges: [
             { text: { ja: '対象項目: スタンダード項目 + SNS・QR情報', en: 'Fields: Standard + Social / QR data' }, tone: 'info' }
         ],

--- a/02_dashboard/src/ui/bizcardSettingsRenderer.js
+++ b/02_dashboard/src/ui/bizcardSettingsRenderer.js
@@ -15,15 +15,38 @@ function getLocalizedText(content, lang) {
     return String(content);
 }
 
-function getBadgeToneClass(tone) {
-    switch (tone) {
-        case 'limit':
-            return 'bg-tertiary-container text-on-tertiary-container';
-        case 'info':
-            return 'bg-secondary-container text-on-secondary-container';
-        default:
-            return 'bg-primary-container text-on-primary-container';
+function findPlanByValue(plans, value) {
+    if (!value) return null;
+    return plans.find(plan => plan.value === value) || null;
+}
+
+function dedupeFeatures(features = []) {
+    const seen = new Set();
+    return features.filter(feature => {
+        if (!feature) return false;
+        const key = feature.key || getLocalizedText(feature.text, 'ja');
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+}
+
+function collectPlanFeatures(plan, plans, visited = new Set()) {
+    if (!plan || visited.has(plan.value)) return [];
+    visited.add(plan.value);
+
+    const ownFeatures = dedupeFeatures([
+        ...(Array.isArray(plan.baseFeatures) ? plan.baseFeatures : []),
+        ...(Array.isArray(plan.additionalFeatures) ? plan.additionalFeatures : [])
+    ]);
+
+    if (!plan.basePlanKey) {
+        return ownFeatures;
     }
+
+    const basePlan = findPlanByValue(plans, plan.basePlanKey);
+    const inherited = collectPlanFeatures(basePlan, plans, visited);
+    return dedupeFeatures([...inherited, ...ownFeatures]);
 }
 
 /**
@@ -186,22 +209,97 @@ export function renderDataConversionPlans(plans, selectedPlan) {
         header.append(title, price);
         label.appendChild(header);
 
-        if (Array.isArray(plan.badges) && plan.badges.length > 0) {
-            const badgeWrapper = document.createElement('div');
-            badgeWrapper.className = 'flex flex-wrap gap-2';
-            plan.badges.forEach(badge => {
-                const badgeEl = document.createElement('span');
-                badgeEl.className = `inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${getBadgeToneClass(badge.tone)}`;
-                badgeEl.textContent = getLocalizedText(badge.text, lang);
-                badgeWrapper.appendChild(badgeEl);
-            });
-            label.appendChild(badgeWrapper);
-        }
-
         const description = document.createElement('p');
         description.className = 'text-sm text-on-surface-variant';
         description.textContent = getLocalizedText(plan.description, lang);
         label.appendChild(description);
+
+        const basePlan = findPlanByValue(plans, plan.basePlanKey);
+        const planName = getLocalizedText(plan.title, lang);
+        const intro = document.createElement('p');
+        intro.className = 'text-sm font-medium text-on-surface';
+        if (basePlan) {
+            const basePlanName = getLocalizedText(basePlan.title, lang);
+            intro.textContent = lang === 'ja'
+                ? `${planName}は${basePlanName}に加えて、次の機能が利用できます。`
+                : `${planName} adds the following on top of ${basePlanName}.`;
+        } else {
+            intro.textContent = lang === 'ja' ? 'このプランで利用可能' : 'Available in this plan';
+        }
+
+        const featureSection = document.createElement('div');
+        featureSection.className = 'space-y-2';
+        featureSection.appendChild(intro);
+
+        const featureList = document.createElement('ul');
+        featureList.className = 'flex flex-wrap gap-2';
+        featureList.setAttribute('role', 'list');
+
+        const featuresToRender = basePlan
+            ? dedupeFeatures(Array.isArray(plan.additionalFeatures) ? plan.additionalFeatures : [])
+            : dedupeFeatures([
+                ...(Array.isArray(plan.baseFeatures) ? plan.baseFeatures : []),
+                ...(Array.isArray(plan.additionalFeatures) ? plan.additionalFeatures : [])
+            ]);
+
+        featuresToRender.forEach(feature => {
+            const item = document.createElement('li');
+            item.className = 'flex';
+            item.setAttribute('role', 'listitem');
+
+            const pill = document.createElement('span');
+            pill.className = [
+                'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold',
+                basePlan
+                    ? 'bg-secondary-container text-on-secondary-container'
+                    : 'bg-primary-container text-on-primary-container'
+            ].join(' ');
+
+            const badgeLabel = document.createElement('span');
+            badgeLabel.className = 'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide';
+            if (basePlan) {
+                badgeLabel.classList.add('bg-primary', 'text-on-primary');
+            } else {
+                badgeLabel.classList.add('bg-secondary', 'text-on-secondary');
+            }
+            badgeLabel.textContent = basePlan ? (lang === 'ja' ? '追加' : 'New') : (lang === 'ja' ? '基本' : 'Included');
+            badgeLabel.setAttribute('aria-hidden', 'true');
+
+            const srPrefix = document.createElement('span');
+            srPrefix.className = 'sr-only';
+            srPrefix.textContent = basePlan
+                ? (lang === 'ja' ? '追加機能: ' : 'Additional feature: ')
+                : (lang === 'ja' ? '含まれる機能: ' : 'Included feature: ');
+
+            const textSpan = document.createElement('span');
+            textSpan.textContent = getLocalizedText(feature.text, lang);
+
+            pill.append(badgeLabel, srPrefix, textSpan);
+            item.appendChild(pill);
+            featureList.appendChild(item);
+        });
+
+        if (featuresToRender.length > 0) {
+            featureSection.appendChild(featureList);
+        }
+
+        if (basePlan) {
+            const inheritedFeatures = collectPlanFeatures(basePlan, plans);
+            if (inheritedFeatures.length > 0) {
+                const srInherited = document.createElement('p');
+                srInherited.className = 'sr-only';
+                const inheritedTexts = inheritedFeatures
+                    .map(feature => getLocalizedText(feature.text, lang))
+                    .filter(Boolean);
+                const basePlanName = getLocalizedText(basePlan.title, lang);
+                srInherited.textContent = lang === 'ja'
+                    ? `${basePlanName}から継承される機能: ${inheritedTexts.join('、')}。`
+                    : `Inherited from ${basePlanName}: ${inheritedTexts.join(', ')}.`;
+                featureSection.appendChild(srInherited);
+            }
+        }
+
+        label.appendChild(featureSection);
 
         const divider = document.createElement('div');
         divider.className = 'border-t border-outline-variant my-2';


### PR DESCRIPTION
## Summary
- model plan inheritance with structured feature metadata for each bizcard data conversion tier
- refresh the plan renderer to show inherited vs new features with accessible badges and runtime deltas
- ensure the UI copy reflects base plan names so comparisons stay accurate if the order shifts

## Testing
- python -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68e77ffcc220832395881ac2482f90e1