### PR TITLE
fix: hydrate coupon state on load

### DIFF
--- a/02_dashboard/bizcardSettings.html
+++ b/02_dashboard/bizcardSettings.html
@@ -122,7 +122,7 @@
                             <div class="input-group">
                                 <input type="text" id="couponCode" placeholder=" " class="input-field pr-20">
                                 <label for="couponCode" class="input-label">クーポンコード</label>
-                                <button id="applyCouponBtn" class="absolute right-2 top-1/2 -translate-y-1/2 bg-primary text-on-primary rounded-md px-4 py-2 text-sm font-semibold hover:bg-primary-dark transition-colors shadow-sm">適用</button>
+                                <button id="applyCouponBtn" type="button" class="coupon-action-button coupon-action-button--apply absolute right-2 top-1/2 -translate-y-1/2 rounded-md px-4 py-2 text-sm font-semibold shadow-sm transition-all focus-visible:outline-none">適用</button>
                                 <p class="input-error-message" id="couponCodeErrorMessage"></p>
                             </div>
                             <p id="couponMessage" class="text-sm -mt-4 text-secondary"></p>

--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -199,6 +199,60 @@ body.dark-mode {
     color: var(--color-button-primary-text);
 }
 
+.coupon-action-button {
+    background-color: transparent;
+    border: none;
+    box-sizing: border-box;
+    color: inherit;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.coupon-action-button:focus {
+    outline: none;
+}
+
+.coupon-action-button:focus-visible {
+    box-shadow: 0 0 0 3px rgba(var(--color-input-border-focus-rgb), 0.35);
+}
+
+.coupon-action-button--apply {
+    background-color: var(--color-button-primary-bg);
+    color: var(--color-button-primary-text);
+}
+
+.coupon-action-button--apply:hover,
+.coupon-action-button--apply:focus-visible {
+    background-color: var(--color-button-primary-hover-bg);
+}
+
+.coupon-action-button--change {
+    background-color: var(--color-button-secondary-bg);
+    color: var(--color-button-secondary-text);
+    border: 1px solid var(--color-button-primary-bg);
+}
+
+.coupon-action-button--change:hover,
+.coupon-action-button--change:focus-visible {
+    background-color: var(--color-button-secondary-hover-bg);
+}
+
+.coupon-action-button--remove {
+    background-color: var(--color-button-danger-bg);
+    color: var(--color-button-danger-text);
+}
+
+.coupon-action-button--remove:hover,
+.coupon-action-button--remove:focus-visible {
+    background-color: var(--color-button-danger-hover-bg);
+    box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.25);
+}
+
+.coupon-action-button.is-processing {
+    cursor: wait;
+    opacity: 0.7;
+}
+
 .button-primary:hover {
     background-color: var(--color-button-primary-hover-bg);
 }

--- a/02_dashboard/src/bizcardSettings.js
+++ b/02_dashboard/src/bizcardSettings.js
@@ -92,7 +92,10 @@ export function initBizcardSettings() {
         surveyId: null,
         settings: {},
         initialSettings: {},
-        appliedCoupon: null
+        appliedCoupon: null,
+        isCouponApplied: false,
+        couponButtonMode: 'apply',
+        isCouponProcessing: false
     };
 
     /**
@@ -121,6 +124,32 @@ export function initBizcardSettings() {
             const parsedBizcardRequest = parseInt(settingsData.bizcardRequest, 10);
             settingsData.bizcardRequest = Number.isFinite(parsedBizcardRequest) ? Math.max(0, parsedBizcardRequest) : 0;
 
+            const normalizedCouponCode = (settingsData.couponCode || '').trim();
+            settingsData.couponCode = normalizedCouponCode;
+
+            let initialCouponFeedback = null;
+            if (normalizedCouponCode) {
+                try {
+                    const validation = await validateCoupon(normalizedCouponCode);
+                    if (validation.success) {
+                        state.appliedCoupon = { ...validation, code: normalizedCouponCode };
+                        state.isCouponApplied = true;
+                    } else {
+                        state.appliedCoupon = null;
+                        state.isCouponApplied = false;
+                    }
+                    initialCouponFeedback = validation;
+                } catch (couponError) {
+                    console.error('初期クーポン検証エラー:', couponError);
+                    state.appliedCoupon = null;
+                    state.isCouponApplied = false;
+                    initialCouponFeedback = {
+                        success: false,
+                        message: '保存済みのクーポン確認に失敗しました。再度適用してください。'
+                    };
+                }
+            }
+
             state.settings = settingsData;
             state.surveyData = surveyData; // surveyDataをstateに保存
             // Deep copy for initial state comparison
@@ -128,6 +157,9 @@ export function initBizcardSettings() {
 
             renderSurveyInfo(surveyData, state.surveyId);
             setInitialFormValues(state.settings);
+            if (initialCouponFeedback) {
+                displayCouponResult(initialCouponFeedback);
+            }
 
             setupEventListeners();
             updateFullUI();
@@ -152,6 +184,9 @@ export function initBizcardSettings() {
         });
         if(bizcardRequestInput) bizcardRequestInput.addEventListener('input', (e) => handleFormChange(e));
 
+        if (couponCodeInput) {
+            couponCodeInput.addEventListener('input', handleCouponInputChange);
+        }
         if(applyCouponBtn) applyCouponBtn.addEventListener('click', handleApplyCoupon);
         if(saveButton) saveButton.addEventListener('click', handleSaveSettings);
         if(cancelButton) cancelButton.addEventListener('click', handleCancel);
@@ -228,23 +263,70 @@ export function initBizcardSettings() {
         updateFullUI();
     }
 
+    function handleCouponInputChange() {
+        updateCouponSectionUI();
+    }
+
     /**
      * Handles the coupon application logic.
      */
     async function handleApplyCoupon() {
+        if (state.isCouponProcessing) {
+            return;
+        }
+
+        const currentMode = state.couponButtonMode;
+
+        if (currentMode === 'remove' && state.appliedCoupon) {
+            state.appliedCoupon = null;
+            state.isCouponApplied = false;
+            state.settings.couponCode = '';
+            couponCodeInput.value = '';
+            displayCouponResult({ success: true, message: 'クーポンを削除しました' });
+            updateFullUI();
+            return;
+        }
+
         const code = couponCodeInput.value.trim();
         if (!code) {
             displayCouponResult({ success: false, message: 'クーポンコードを入力してください。' });
             return;
         }
-        const result = await validateCoupon(code);
-        displayCouponResult(result);
-        if (result.success) {
-            state.appliedCoupon = result;
-        } else {
-            state.appliedCoupon = null;
+
+        state.isCouponProcessing = true;
+        updateCouponSectionUI();
+
+        const previousCoupon = state.appliedCoupon;
+
+        try {
+            const result = await validateCoupon(code);
+            displayCouponResult(result);
+            if (result.success) {
+                state.appliedCoupon = { ...result, code };
+                state.settings.couponCode = code;
+            } else {
+                if (previousCoupon && previousCoupon.code && previousCoupon.code !== code) {
+                    state.appliedCoupon = previousCoupon;
+                    state.settings.couponCode = previousCoupon.code;
+                } else {
+                    state.appliedCoupon = null;
+                    state.settings.couponCode = '';
+                }
+            }
+        } catch (error) {
+            console.error('クーポン検証エラー:', error);
+            displayCouponResult({ success: false, message: 'クーポンの検証中にエラーが発生しました。再度お試しください。' });
+            if (previousCoupon && previousCoupon.code) {
+                state.appliedCoupon = previousCoupon;
+                state.settings.couponCode = previousCoupon.code;
+            } else {
+                state.appliedCoupon = null;
+                state.settings.couponCode = '';
+            }
+        } finally {
+            state.isCouponProcessing = false;
+            updateFullUI();
         }
-        updateFullUI();
     }
 
     /**
@@ -336,7 +418,59 @@ export function initBizcardSettings() {
 
         const estimate = calculateEstimate(state.settings, state.appliedCoupon, state.surveyData?.periodEnd);
         renderEstimate(estimate);
+        updateCouponSectionUI();
         validateForm();
+    }
+
+    function updateCouponSectionUI() {
+        if (!couponCodeInput || !applyCouponBtn) {
+            return;
+        }
+
+        const trimmedValue = couponCodeInput.value.trim();
+        const appliedCoupon = state.appliedCoupon;
+        const hasAppliedCoupon = Boolean(appliedCoupon);
+
+        let mode = 'apply';
+        if (hasAppliedCoupon) {
+            const appliedCode = appliedCoupon.code || '';
+            if (trimmedValue && trimmedValue !== appliedCode) {
+                mode = 'change';
+            } else {
+                mode = 'remove';
+            }
+        }
+
+        state.isCouponApplied = hasAppliedCoupon;
+        state.couponButtonMode = mode;
+
+        const labels = {
+            apply: '適用',
+            change: '変更',
+            remove: '削除'
+        };
+        const ariaLabels = {
+            apply: '入力したクーポンコードを適用する',
+            change: '入力したクーポンコードで適用内容を変更する',
+            remove: '適用済みのクーポンを削除する'
+        };
+
+        applyCouponBtn.textContent = labels[mode];
+        applyCouponBtn.setAttribute('aria-label', ariaLabels[mode]);
+        applyCouponBtn.setAttribute('aria-pressed', mode === 'remove' ? 'true' : 'false');
+
+        applyCouponBtn.classList.remove('coupon-action-button--apply', 'coupon-action-button--change', 'coupon-action-button--remove');
+        applyCouponBtn.classList.add(`coupon-action-button--${mode}`);
+
+        applyCouponBtn.disabled = state.isCouponProcessing;
+        applyCouponBtn.setAttribute('aria-busy', state.isCouponProcessing ? 'true' : 'false');
+        couponCodeInput.disabled = state.isCouponProcessing;
+        couponCodeInput.setAttribute('aria-disabled', state.isCouponProcessing ? 'true' : 'false');
+        if (state.isCouponProcessing) {
+            applyCouponBtn.classList.add('is-processing');
+        } else {
+            applyCouponBtn.classList.remove('is-processing');
+        }
     }
 
     // --- Initialize Page ---


### PR DESCRIPTION
## Summary
- validate saved coupon codes during initialization so the UI reflects applied coupons and shows stored messaging
- set the coupon action button's pressed state only when the remove action is active for accurate accessibility semantics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e77fff22b88323bb74ce0b05c47723