### PR TITLE
fix: standardize main content widths to max-w-6xl

### DIFF
--- a/02_dashboard/bizcardSettings.html
+++ b/02_dashboard/bizcardSettings.html
@@ -50,7 +50,7 @@
                     </div>
                 </div>
 
-                <div class="w-full max-w-7xl mx-auto">
+                <div class="w-full max-w-6xl mx-auto">
                     <div class="flex flex-col lg:flex-row gap-6">
                     <!-- 名刺データ化設定フォーム -->
                     <div class="bg-surface p-6 rounded-xl space-y-6">

--- a/02_dashboard/common/footer.html
+++ b/02_dashboard/common/footer.html
@@ -1,5 +1,5 @@
 <footer class="border-t border-outline-variant bg-surface-variant" id="main-footer">
-    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-12">
         <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-8">
             <div class="col-span-2 md:col-span-4 lg:col-span-1">
                 <div class="flex items-center gap-2 text-on-surface mb-4">

--- a/02_dashboard/layout_fix_example.html
+++ b/02_dashboard/layout_fix_example.html
@@ -53,7 +53,7 @@
         }
         /* コンテンツを中央に配置するためのラッパー */
         .content-wrapper {
-            max-width: 1152px; /* プロジェクトのmax-w-7xlに対応 */
+            max-width: 1152px; /* プロジェクトの推奨幅 max-w-6xl に対応 */
             margin: 0 auto; /* 水平方向の中央揃え */
             padding: 2rem;
             background-color: white;

--- a/03_admin/data_entry.html
+++ b/03_admin/data_entry.html
@@ -22,7 +22,7 @@
             <div id="header-placeholder"></div>
 
             <main class="flex-1 p-4 md:p-6">
-                <div class="max-w-7xl mx-auto">
+                <div class="max-w-6xl mx-auto">
                     <!-- Page Title -->
                     <h1 class="text-2xl font-bold text-on-background mb-6">データ入力状況</h1>
 

--- a/03_admin/sample/data_entry_admin_form.html
+++ b/03_admin/sample/data_entry_admin_form.html
@@ -52,7 +52,7 @@
 
             <!-- Main Content -->
             <main class="flex-1 p-4 md:p-6 overflow-y-auto">
-                <div class="max-w-7xl mx-auto">
+                <div class="max-w-6xl mx-auto">
                     <div class="flex justify-between items-center mb-4">
                                                                         <h1 class="text-xl font-bold">
                             <span id="user-email">operator@example.com</span>：<span id="user-name">山田 太郎</span>

--- a/03_admin/src/data_entry.js
+++ b/03_admin/src/data_entry.js
@@ -11,7 +11,7 @@ async function fetchData() {
     } catch (error) {
         console.error("Could not fetch data:", error);
         // Display an error message on the page
-        const mainContent = document.querySelector('main .max-w-7xl');
+        const mainContent = document.querySelector('main .max-w-6xl');
         if(mainContent) {
             mainContent.innerHTML = `
                 <div class="bg-gray-800 p-6 rounded-lg text-center">


### PR DESCRIPTION
## Summary
- align admin data entry templates with the shared max-w-6xl layout width
- update bizcard settings and shared footer wrappers to the same width guideline
- refresh documentation sample to reference the new standard and keep helper script selectors in sync

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68e791ebb27883238e05e006973fbfeb