### PR TITLE
fix: align bizcard speed ids and defaults

### DIFF
--- a/02_dashboard/bizcardSettings.html
+++ b/02_dashboard/bizcardSettings.html
@@ -74,7 +74,7 @@
                             <div class="space-y-2">
                                 <h2 class="text-on-surface text-xl font-bold mb-4">データ化スピードプラン（納期オプション）</h2>
                                 <p class="text-sm text-on-surface-variant mb-2">作業スピードに応じて@単価が変動します。ご希望の納期に合わせて選択してください。</p>
-                                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4" id="workPlanSelection">
+                                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4" id="dataConversionSpeedSelection">
                                     
                                     <div class="relative">
                                         <input class="sr-only peer" type="radio" id="normalPlan" name="dataConversionSpeed" value="normal" checked>
@@ -93,7 +93,7 @@
                                     </div>
 
                                     <div class="relative">
-                                        <input class="sr-only peer" type="radio" id="superExpressPlan" name="dataConversionSpeed" value="super-express">
+                                        <input class="sr-only peer" type="radio" id="superExpressPlan" name="dataConversionSpeed" value="superExpress">
                                         <label class="flex flex-col items-center p-4 bg-surface-container rounded-lg border border-outline cursor-pointer peer-checked:border-primary peer-checked:ring-1 peer-checked:ring-primary peer-disabled:opacity-50 peer-disabled:cursor-not-allowed" for="superExpressPlan">
                                             <span class="text-on-surface font-semibold">超特急プラン</span>
                                             <span class="text-on-surface-variant text-sm mt-1">納期目安: 1営業日</span>
@@ -101,7 +101,7 @@
                                     </div>
 
                                     <div class="relative">
-                                        <input class="sr-only peer" type="radio" id="ondemandPlan" name="dataConversionSpeed" value="ondemand">
+                                        <input class="sr-only peer" type="radio" id="ondemandPlan" name="dataConversionSpeed" value="onDemand">
                                         <label class="flex flex-col items-center p-4 bg-surface-container rounded-lg border border-outline cursor-pointer peer-checked:border-primary peer-checked:ring-1 peer-checked:ring-primary peer-disabled:opacity-50 peer-disabled:cursor-not-allowed" for="ondemandPlan">
                                             <span class="text-on-surface font-semibold whitespace-nowrap">オンデマンドプラン</span>
                                             <span class="text-on-surface-variant text-sm mt-1">納期目安: 当日中</span>
@@ -112,7 +112,7 @@
 
                             <!-- 見込み枚数 -->
                             <div class="input-group">
-                                <input type="number" id="bizcardRequest" min="1" placeholder=" " class="input-field">
+                                <input type="number" id="bizcardRequest" min="1" placeholder=" " class="input-field" value="100">
                                 <label for="bizcardRequest" class="input-label">見込み枚数</label>
                                 <span class="absolute right-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-sm">枚</span>
                                 <p class="input-error-message"></p>

--- a/02_dashboard/src/bizcardSettings.js
+++ b/02_dashboard/src/bizcardSettings.js
@@ -236,7 +236,9 @@ export function initBizcardSettings() {
             settingsData.dataConversionPlan = settingsData.dataConversionPlan || 'free';
             settingsData.dataConversionSpeed = settingsData.dataConversionSpeed || 'normal';
             const parsedBizcardRequest = parseInt(settingsData.bizcardRequest, 10);
-            settingsData.bizcardRequest = Number.isFinite(parsedBizcardRequest) ? Math.max(0, parsedBizcardRequest) : 0;
+            settingsData.bizcardRequest = Number.isFinite(parsedBizcardRequest) && parsedBizcardRequest > 0
+                ? parsedBizcardRequest
+                : 100;
 
             const normalizedCouponCode = (settingsData.couponCode || '').trim();
             settingsData.couponCode = normalizedCouponCode;
@@ -288,10 +290,10 @@ export function initBizcardSettings() {
      * Sets up all event listeners for the page.
      */
     function setupEventListeners() {
-        const workPlanSelection = document.getElementById('workPlanSelection');
         const formElements = [
             bizcardRequestInput,
-            dataConversionPlanSelection, dataConversionSpeedSelection, workPlanSelection
+            dataConversionPlanSelection,
+            dataConversionSpeedSelection
         ];
         formElements.forEach(el => {
             if(el) el.addEventListener('change', (e) => handleFormChange(e));
@@ -500,7 +502,7 @@ export function initBizcardSettings() {
         });
 
         if (isTrialPlan) {
-            const normalPlanRadio = document.getElementById('normalPlan');
+            const normalPlanRadio = document.querySelector('input[name="dataConversionSpeed"][value="normal"]');
             if (normalPlanRadio) normalPlanRadio.checked = true;
             state.settings.dataConversionSpeed = 'normal';
         }
@@ -511,7 +513,14 @@ export function initBizcardSettings() {
         if (!state.settings.dataConversionSpeed) {
             state.settings.dataConversionSpeed = 'normal';
         }
-        state.settings.bizcardRequest = Math.max(0, parseInt(state.settings.bizcardRequest, 10) || 0);
+        const parsedBizcardRequest = parseInt(state.settings.bizcardRequest, 10);
+        state.settings.bizcardRequest = Number.isFinite(parsedBizcardRequest) && parsedBizcardRequest > 0
+            ? parsedBizcardRequest
+            : 100;
+
+        if (bizcardRequestInput) {
+            bizcardRequestInput.value = state.settings.bizcardRequest;
+        }
 
         renderDataConversionPlans(DATA_CONVERSION_PLANS, state.settings.dataConversionPlan);
 

--- a/02_dashboard/src/services/bizcardSettingsService.js
+++ b/02_dashboard/src/services/bizcardSettingsService.js
@@ -59,7 +59,7 @@ export async function fetchBizcardSettings(surveyId) {
         // フォールバック用のデフォルト設定
         return {
             bizcardEnabled: false,
-            bizcardRequest: 0,
+            bizcardRequest: 100,
             dataConversionPlan: 'standard',
             dataConversionSpeed: 'normal',
             couponCode: '',

--- a/02_dashboard/src/ui/bizcardSettingsRenderer.js
+++ b/02_dashboard/src/ui/bizcardSettingsRenderer.js
@@ -98,7 +98,7 @@ export function setInitialFormValues(settings) {
     const planValue = settings.dataConversionPlan || 'free';
     const speedValue = settings.dataConversionSpeed || 'normal';
     const parsedRequest = parseInt(settings.bizcardRequest, 10);
-    const requestCount = Number.isFinite(parsedRequest) ? Math.max(0, parsedRequest) : 0;
+    const requestCount = Number.isFinite(parsedRequest) && parsedRequest > 0 ? parsedRequest : 100;
 
     dom.bizcardRequestInput.value = requestCount;
     dom.couponCodeInput.value = settings.couponCode || '';

--- a/docs/reviews/bizcard-settings.md
+++ b/docs/reviews/bizcard-settings.md
@@ -1,0 +1,13 @@
+# Bizcard Settings Screen Review
+
+## 1. データ化スピードプランのDOM ID不整合
+- **内容**: `renderDataConversionSpeeds` は `id="dataConversionSpeedSelection"` を持つ要素にスピードプランカードを描画する設計ですが、テンプレートでは `id="workPlanSelection"` が使用されています。そのためレンダラーがDOMを取得できず、スピードプランのカード（単価表示など）が描画されません。
+- **根拠**: テンプレート側のID指定とJS側の取得先の不一致。`initBizcardSettings` と `bizcardSettingsRenderer` が `dataConversionSpeedSelection` を参照している一方で、HTMLは `workPlanSelection` を定義しています。【F:02_dashboard/src/bizcardSettings.js†L191-L531】【F:02_dashboard/src/ui/bizcardSettingsRenderer.js†L55-L112】【F:02_dashboard/bizcardSettings.html†L60-L110】
+- **影響**: 期待したスピードプランカードが表示されず、単価や付随情報がUIに出ないため利用者が料金を確認できません。さらに、後述の値不整合を誘発し、見積もり計算にも波及しています。
+- **提案**: テンプレートのIDを `dataConversionSpeedSelection` に変更するか、JS側の取得IDを `workPlanSelection` に統一してください。加えて、レンダラーが動作した際に `updateFullUI` の `normalPlan` 参照が破綻しないよう、`document.querySelector('input[name="dataConversionSpeed"][value="normal"]')` など値ベースの参照へ更新することを推奨します。
+
+## 2. スピード値の命名不一致による見積もり計算の破綻
+- **内容**: テンプレートのラジオボタン値が `value="super-express"` / `value="ondemand"` であるのに対し、見積もり計算が参照する `SPEED_OPTIONS` のキーは `superExpress` / `onDemand` です。`handleFormChange` はラジオの値をそのまま `state.settings.dataConversionSpeed` に格納するため、該当オプションを選択すると `calculateEstimate` が速度設定を解決できず、単価・納期が0のままになります。
+- **根拠**: ラジオの値と速度オプションのキーが一致していないこと、`calculateEstimate` が `SPEED_OPTIONS[selectedSpeed]` で解決していることが確認できます。【F:02_dashboard/bizcardSettings.html†L73-L109】【F:02_dashboard/src/bizcardSettings.js†L358-L377】【F:02_dashboard/src/services/bizcardCalculator.js†L15-L52】
+- **影響**: 「超特急」「オンデマンド」プランを選んだ場合に見積もり金額が常に¥0、納期が初期値（通常プラン相当）のままとなる重大な計算誤りです。請求見込みが過小表示され、ユーザーや営業判断を誤らせます。
+- **提案**: スピードラジオの `value` を `superExpress` / `onDemand` など `SPEED_OPTIONS` と一致する形へ修正してください。上記DOM ID不整合を解消してレンダラー側に委譲すれば、キー整合性も一括管理できます。


### PR DESCRIPTION
## Summary
- update the Bizcard Settings template so speed selection IDs and option values match the renderer and calculator
- ensure Bizcard Settings defaults use 100 cards when no positive count is provided and keep inputs in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7912a8d0c832399017009b0b925e4