### PR TITLE
fix: prevent duplicate qr modal listener

### DIFF
--- a/02_dashboard/src/surveyCreation.js
+++ b/02_dashboard/src/surveyCreation.js
@@ -664,12 +664,14 @@ function updateAndRenderAll() {
         qrButton.disabled = !canOpenQr;
         qrButton.setAttribute('aria-disabled', !canOpenQr ? 'true' : 'false');
         qrButton.classList.toggle('opacity-50', !canOpenQr);
-    }
 
-    if (openQrModalBtn) {
-        openQrModalBtn.addEventListener('click', () => {
-            loadModal('qrCodeModal', setupQrCodeModalListeners);
-        });
+        if (!qrButton.dataset.qrModalListenerAttached) {
+            qrButton.addEventListener('click', () => {
+                if (qrButton.disabled) return;
+                handleOpenModal('qrCodeModal', 'modals/qrCodeModal.html', setupQrCodeModalListeners);
+            });
+            qrButton.dataset.qrModalListenerAttached = 'true';
+        }
     }
 
     updateOutlineActionsState();


### PR DESCRIPTION
## Summary
- use the QR code button reference retrieved in `updateAndRenderAll` and prevent duplicate listeners via `dataset`
- invoke `handleOpenModal` for the QR modal instead of the undefined `loadModal`

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7a7d5eaf88323862da00e39b07219