### PR TITLE
Simplify invoice list layout and filter UI

### DIFF
--- a/02_dashboard/invoiceList.html
+++ b/02_dashboard/invoiceList.html
@@ -7,7 +7,6 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="service-top-style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
   <link
     as="style"
@@ -27,35 +26,32 @@
         <div class="flex flex-col w-full max-w-6xl mx-auto flex-1">
           <div id="breadcrumb-container" class="mb-4"></div>
 
-          <div class="flex flex-wrap justify-between items-center gap-4 mb-6 pb-4 border-b border-outline-variant">
-            <h1 class="text-on-background text-2xl sm:text-3xl font-bold leading-tight tracking-tight">請求書一覧</h1>
-            <p class="text-sm text-on-surface-variant">最新の請求データをサービスプラン別に確認できます。</p>
+          <div class="flex flex-col gap-6">
+            <div class="flex flex-col gap-2">
+              <h1 class="text-on-background text-2xl sm:text-3xl font-bold leading-tight tracking-tight">請求書一覧</h1>
+              <p class="text-sm text-on-surface-variant">直近の請求状況を確認できます。</p>
+            </div>
+
+            <div class="flex flex-col gap-4 rounded-xl border border-outline-variant bg-surface p-5 shadow-sm">
+              <form id="invoice-filter-form" class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <label class="flex flex-col gap-1 text-sm text-on-surface-variant" for="invoice-status-filter">
+                  ステータスで絞り込み
+                  <select id="invoice-status-filter" name="invoiceStatus" class="mt-1 rounded-lg border border-outline-variant bg-surface px-3 py-2 text-sm text-on-background focus:border-primary focus:outline-none">
+                    <option value="all">すべて</option>
+                    <option value="unpaid">未入金</option>
+                    <option value="paid">入金済</option>
+                    <option value="overdue">延滞</option>
+                    <option value="canceled">取消</option>
+                  </select>
+                </label>
+                <p id="invoice-result-count" class="text-sm text-on-surface-variant sm:text-right">0件表示中</p>
+              </form>
+
+              <div id="invoice-status-message" role="status" aria-live="polite" class="hidden flex items-center gap-3 rounded-lg border px-4 py-3 text-sm"></div>
+
+              <ul id="invoice-card-list" class="flex flex-col gap-4" aria-label="請求書一覧"></ul>
+            </div>
           </div>
-
-          <section class="overflow-x-auto rounded-xl border border-outline-variant bg-surface relative min-h-[200px]">
-            <table class="w-full min-w-[1100px] divide-y divide-outline-variant survey-table" id="invoiceTable">
-              <thead class="bg-surface-variant">
-                <tr>
-                  <th class="px-4 py-3 text-left text-on-surface-variant text-xs font-semibold uppercase tracking-wider">請求月</th>
-                  <th class="px-4 py-3 text-left text-on-surface-variant text-xs font-semibold uppercase tracking-wider">請求書ID</th>
-                  <th class="px-4 py-3 text-left text-on-surface-variant text-xs font-semibold uppercase tracking-wider">契約プラン</th>
-                  <th class="px-4 py-3 text-left text-on-surface-variant text-xs font-semibold uppercase tracking-wider">請求金額（税込）</th>
-                  <th class="px-4 py-3 text-left text-on-surface-variant text-xs font-semibold uppercase tracking-wider">ステータス</th>
-                  <th class="px-4 py-3 text-left text-on-surface-variant text-xs font-semibold uppercase tracking-wider">詳細</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-outline-variant" id="invoice-table-body">
-              </tbody>
-            </table>
-
-            <div id="invoice-loading-overlay" class="absolute inset-0 bg-surface bg-opacity-75 flex items-center justify-center hidden">
-              <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
-            </div>
-
-            <div id="invoice-message-overlay" class="absolute inset-0 bg-surface bg-opacity-75 flex items-center justify-center hidden">
-              <p class="text-on-surface-variant text-lg"></p>
-            </div>
-          </section>
         </div>
       </main>
     </div>
@@ -63,8 +59,6 @@
     <div id="footer-placeholder"></div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-  <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/ja.js"></script>
   <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/02_dashboard/src/invoiceList.js
+++ b/02_dashboard/src/invoiceList.js
@@ -1,19 +1,70 @@
 import { fetchInvoices } from './services/invoiceService.js';
 import { renderInvoices, showLoading, hideLoading, showMessage } from './ui/invoiceRenderer.js';
 
+let allInvoices = [];
+let hasLoadedInvoices = false;
+
+function filterInvoicesByStatus(status) {
+  if (status === 'all') {
+    return [...allInvoices];
+  }
+  return allInvoices.filter(invoice => invoice?.status === status);
+}
+
+function applyFilter(status) {
+  if (!hasLoadedInvoices) return;
+
+  const targetStatus = status ?? 'all';
+  const filtered = filterInvoicesByStatus(targetStatus);
+
+  if (filtered.length === 0) {
+    const message = targetStatus === 'all'
+      ? '対象の請求書がありません。'
+      : '該当する請求書がありません。';
+    showMessage(message);
+  }
+
+  renderInvoices(filtered);
+}
+
 export async function initInvoiceListPage() {
+  const filterSelect = document.getElementById('invoice-status-filter');
+
+  if (filterSelect) {
+    filterSelect.addEventListener('change', () => {
+      applyFilter(filterSelect.value);
+    });
+  }
+
   showLoading();
 
   try {
     const invoices = await fetchInvoices();
-    if (!Array.isArray(invoices) || invoices.length === 0) {
-      showMessage('対象の請求書がありません。');
+    allInvoices = Array.isArray(invoices) ? invoices : [];
+    hasLoadedInvoices = true;
+
+    if (allInvoices.length === 0) {
+      showMessage('対象の請求書がありません。', {
+        action: {
+          label: '再読み込み',
+          onClick: () => window.location.reload()
+        }
+      });
+      renderInvoices([]);
     } else {
-      renderInvoices(invoices);
+      const initialFilter = filterSelect ? filterSelect.value : 'all';
+      applyFilter(initialFilter);
     }
   } catch (error) {
     console.error('Failed to load invoices:', error);
-    showMessage('請求データの取得に失敗しました。ページを再読み込みしてください。');
+    showMessage('請求データの取得に失敗しました。ページを再読み込みしてください。', {
+      tone: 'error',
+      action: {
+        label: '再読み込み',
+        onClick: () => window.location.reload()
+      }
+    });
+    renderInvoices([]);
   } finally {
     hideLoading();
   }


### PR DESCRIPTION
## Summary
- replace the invoice table with a card-based list and inline status filter
- render invoice cards with DOM APIs and show contextual status messaging
- remove unused Flatpickr assets from the invoice list entry point

## Testing
- Not run (UI change only)

## Screenshots
![Invoice list cards](browser:/invocations/qqcaiphy/artifacts/artifacts/invoice-list.png)

------
https://chatgpt.com/codex/tasks/task_e_68ee05dae5508323aeb0c9da90ba97b0