### PR TITLE
chore: add mock surveys for early lifecycle states

### DIFF
--- a/data/surveys/surveys-with-details.json
+++ b/data/surveys/surveys-with-details.json
@@ -1962,5 +1962,133 @@
             }
         ],
         "createdAt": "2025-11-25T00:00:00+09:00"
+    },
+    {
+        "id": "sv_0001_27001",
+        "groupId": "GROUP_MKT2026",
+        "name": {
+            "ja": "2026\u5e74\u6625\u5b63\u5c55\u793a\u4f1a\u30a2\u30f3\u30b1\u30fc\u30c8",
+            "en": "Spring 2026 Expo Feedback"
+        },
+        "displayTitle": {
+            "ja": "\u6625\u5b63\u5c55\u793a\u4f1a\u3078\u306e\u3054\u6765\u5834\u3042\u308a\u304c\u3068\u3046\u3054\u3056\u3044\u307e\u3059",
+            "en": "Thank you for visiting our Spring Expo"
+        },
+        "description": {
+            "ja": "2026\u5e74\u6625\u5b63\u5c55\u793a\u4f1a\u306b\u5411\u3051\u305f\u6e96\u5099\u72b6\u6cc1\u3092\u628a\u63e1\u3059\u308b\u305f\u3081\u306e\u4e8b\u524d\u30a2\u30f3\u30b1\u30fc\u30c8\u3067\u3059\u3002",
+            "en": "Pre-event survey to understand expectations for the 2026 Spring Expo."
+        },
+        "memo": "\u30de\u30fc\u30b1\u30c6\u30a3\u30f3\u30b0\u672c\u90e8\u3088\u308a\u4f9d\u983c\u3002VIP\u5411\u3051\u4f53\u9a13\u30c7\u30e2\u306e\u4e8b\u524d\u5e0c\u671b\u3092\u96c6\u7d04\u3002",
+        "status": "\u6e96\u5099\u4e2d",
+        "answerCount": 0,
+        "realtimeAnswers": 0,
+        "periodStart": "2026-03-15",
+        "periodEnd": "2026-04-05",
+        "dataCompletionDate": "",
+        "plan": "Premium",
+        "deadline": "2026-07-05",
+        "estimatedBillingAmount": 180000,
+        "bizcardEnabled": true,
+        "bizcardRequest": 240,
+        "bizcardCompletionCount": 0,
+        "thankYouEmailSettings": "\u672a\u8a2d\u5b9a",
+        "details": [
+            {
+                "id": "q1",
+                "text": "Q.01_\u6765\u5834\u4e88\u5b9a\u65e5",
+                "type": "single_choice",
+                "options": [
+                    "\u521d\u65e5(3/15)",
+                    "\u4f1a\u671f\u4e2d(3/16-3/31)",
+                    "\u6700\u7d42\u65e5(4/5)",
+                    "\u672a\u5b9a"
+                ]
+            },
+            {
+                "id": "q2",
+                "text": "Q.02_\u6ce8\u76ee\u3057\u3066\u3044\u308b\u5c55\u793a\u30ab\u30c6\u30b4\u30ea\uff08\u8907\u6570\u9078\u629e\u53ef\uff09",
+                "type": "multi_choice",
+                "options": [
+                    "AI\u30fb\u81ea\u52d5\u5316\u30bd\u30ea\u30e5\u30fc\u30b7\u30e7\u30f3",
+                    "\u30b5\u30b9\u30c6\u30ca\u30d6\u30eb\u88fd\u54c1",
+                    "\u6700\u65b0\u52a0\u5de5\u6a5f\u30e9\u30a4\u30f3\u30a2\u30c3\u30d7",
+                    "\u30aa\u30f3\u30e9\u30a4\u30f3\u9023\u643a\u30b5\u30fc\u30d3\u30b9"
+                ]
+            },
+            {
+                "id": "q3",
+                "text": "Q.03_\u62c5\u5f53\u55b6\u696d\u3068\u306e\u4e8b\u524d\u6253\u3061\u5408\u308f\u305b\u5e0c\u671b",
+                "type": "single_choice",
+                "options": [
+                    "\u5e0c\u671b\u3059\u308b",
+                    "\u30e1\u30fc\u30eb\u3067\u60c5\u5831\u306e\u307f\u6b32\u3057\u3044",
+                    "\u5f53\u65e5\u76f8\u8ac7\u3057\u305f\u3044",
+                    "\u7279\u306b\u5e0c\u671b\u3057\u306a\u3044"
+                ]
+            }
+        ],
+        "createdAt": "2025-12-15T09:30:00+09:00"
+    },
+    {
+        "id": "sv_0001_26950",
+        "groupId": "GROUP_EVENT2025",
+        "name": {
+            "ja": "\u30b0\u30ed\u30fc\u30d0\u30eb\u30d1\u30fc\u30c8\u30ca\u30fc\u4ea4\u6d41\u4f1a\u30a2\u30f3\u30b1\u30fc\u30c8",
+            "en": "Global Partner Meetup Survey"
+        },
+        "displayTitle": {
+            "ja": "\u4ea4\u6d41\u4f1a\u306e\u3054\u610f\u898b\u3092\u304a\u805e\u304b\u305b\u304f\u3060\u3055\u3044",
+            "en": "Share your feedback on the partner meetup"
+        },
+        "description": {
+            "ja": "\u6d77\u5916\u30d1\u30fc\u30c8\u30ca\u30fc\u3068\u306e\u4ea4\u6d41\u30a4\u30d9\u30f3\u30c8\u3067\u306e\u6e80\u8db3\u5ea6\u3084\u8981\u671b\u3092\u628a\u63e1\u3059\u308b\u305f\u3081\u306e\u30a2\u30f3\u30b1\u30fc\u30c8\u3067\u3059\u3002",
+            "en": "Survey capturing satisfaction and requests from the global partner meetup."
+        },
+        "memo": "\u55b6\u696d\u63a8\u9032\u90e8\uff0f\u73fe\u5730\u30b9\u30bf\u30c3\u30d5\u5171\u6709\u7528\u3002\u30ea\u30a2\u30eb\u30bf\u30a4\u30e0\u56de\u7b54\u3092Slack\u9023\u643a\u3002",
+        "status": "\u516c\u958b\u4e2d",
+        "answerCount": 58,
+        "realtimeAnswers": 12,
+        "periodStart": "2024-11-20",
+        "periodEnd": "2026-02-28",
+        "dataCompletionDate": "",
+        "plan": "Enterprise",
+        "deadline": "2026-05-31",
+        "estimatedBillingAmount": 240000,
+        "bizcardEnabled": true,
+        "bizcardRequest": 320,
+        "bizcardCompletionCount": 198,
+        "thankYouEmailSettings": "\u81ea\u52d5\u9001\u4fe1",
+        "details": [
+            {
+                "id": "q1",
+                "text": "Q.01_\u30a4\u30d9\u30f3\u30c8\u5168\u4f53\u306e\u6e80\u8db3\u5ea6",
+                "type": "single_choice",
+                "options": [
+                    "\u3068\u3066\u3082\u6e80\u8db3",
+                    "\u3084\u3084\u6e80\u8db3",
+                    "\u666e\u901a",
+                    "\u3084\u3084\u4e0d\u6e80",
+                    "\u3068\u3066\u3082\u4e0d\u6e80"
+                ]
+            },
+            {
+                "id": "q2",
+                "text": "Q.02_\u5370\u8c61\u306b\u6b8b\u3063\u305f\u30b3\u30f3\u30c6\u30f3\u30c4\uff08\u8907\u6570\u9078\u629e\u53ef\uff09",
+                "type": "multi_choice",
+                "options": [
+                    "\u57fa\u8abf\u8b1b\u6f14",
+                    "\u30d1\u30cd\u30eb\u30c7\u30a3\u30b9\u30ab\u30c3\u30b7\u30e7\u30f3",
+                    "\u5c55\u793a\u30d6\u30fc\u30b9\u30c4\u30a2\u30fc",
+                    "\u30cd\u30c3\u30c8\u30ef\u30fc\u30ad\u30f3\u30b0\u30bb\u30c3\u30b7\u30e7\u30f3",
+                    "\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
+                ]
+            },
+            {
+                "id": "q3",
+                "text": "Q.03_\u4eca\u5f8c\u306e\u5354\u696d\u5e0c\u671b\u5206\u91ce",
+                "type": "free_text"
+            }
+        ],
+        "createdAt": "2025-10-02T14:15:00+09:00"
     }
 ]


### PR DESCRIPTION
## Summary
- append a Premium mock survey scheduled for 2026 so it appears as 会期前 in the dashboard list
- add an Enterprise mock survey spanning 2024-2026 so it renders as 会期中 ahead of other records

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f5dc39342c8323b05427eefd926d5f