### PR TITLE
feat(calendar): display normal surveys on the calendar

### DIFF
--- a/03_admin/calendar-management.html
+++ b/03_admin/calendar-management.html
@@ -77,6 +77,7 @@
                                     <span class="inline-flex items-center gap-1"><span class="size-3 rounded-full bg-green-200"></span>アサイン済</span>
                                     <span class="inline-flex items-center gap-1"><span class="size-3 rounded-full bg-yellow-200"></span>未アサイン</span>
                                     <span class="inline-flex items-center gap-1"><span class="size-3 rounded-full bg-red-200"></span>緊急</span>
+                                    <span class="inline-flex items-center gap-1"><span class="text-blue-600 font-bold">・</span>通常アンケート</span>
                                 </div>
 
                             </div>

--- a/03_admin/src/calendar-management.js
+++ b/03_admin/src/calendar-management.js
@@ -95,6 +95,7 @@ export function initCalendarManagementPage() {
             const isUrgent = state.urgencyOverrides[dateString]; // Manual override
             const dayAssignments = state.assignmentOverrides[dateString];
             const onDemandSurveys = surveysForDay.filter(s => s.type === 'on-demand');
+            const regularSurveys = surveysForDay.filter(s => s.type === 'normal');
 
             let surveyBgClass = ''; // Initialize background class
 
@@ -127,6 +128,9 @@ export function initCalendarManagementPage() {
                     <p>見込枚数: ${totalCards.toLocaleString()}</p>
                 </div>
             `;
+                if (regularSurveys.length > 0) {
+                    dayInfoHTML += `<p class="text-xs text-blue-600 font-semibold mt-1">・通常アンケートあり</p>`;
+                }
                 const surveyTitles = surveysForDay.map(s => s.name).join(', ');
                 cellTitle = surveyTitles;
             }

--- a/data/admin/surveys.json
+++ b/data/admin/surveys.json
@@ -28,5 +28,15 @@
     "status": "assigned",
     "urgency": "high",
     "type": "on-demand"
+  },
+  {
+    "id": 4,
+    "name": "【10月】通常アンケート",
+    "startDate": "2025-10-01",
+    "endDate": "2025-10-10",
+    "expected_cards": 800,
+    "status": "pending",
+    "urgency": "low",
+    "type": "normal"
   }
 ]


### PR DESCRIPTION
Closes #111

### Description

This PR implements the functionality to display normal surveys on the calendar page.

- Adds a legend for normal surveys.
- Displays a blue dot on days that have a normal survey.
- Adds test data for a normal survey.