### PR TITLE
fix: load survey data via dashboard resolver

### DIFF
--- a/02_dashboard/src/survey-answer.js
+++ b/02_dashboard/src/survey-answer.js
@@ -3,6 +3,8 @@
  * アンケート回答画面のフロントエンドロジック
  */
 
+import { resolveDashboardDataPath } from './utils.js';
+
 // --- 状態管理 ---
 const state = {
     surveyId: null,
@@ -138,7 +140,7 @@ function normalizeOptions(options, questionId) {
 }
 
 async function loadSurveyData() {
-    const response = await fetch(`/data/demo_surveys/${state.surveyId}.json`);
+    const response = await fetch(resolveDashboardDataPath(`demo_surveys/${state.surveyId}.json`));
     if (!response.ok) {
         throw new Error(`アンケート定義ファイルが見つかりません (ID: ${state.surveyId})`);
     }


### PR DESCRIPTION
## Summary
- import the dashboard data path resolver in the survey answer module
- fetch survey definitions via resolveDashboardDataPath to use the configured base path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690abb93cc888323bf4dea739935e544)