### PR TITLE
fix: resolve survey data path in answer page

### DIFF
--- a/02_dashboard/src/survey-answer.js
+++ b/02_dashboard/src/survey-answer.js
@@ -3,6 +3,8 @@
  * アンケート回答画面のフロントエンドロジック
  */
 
+import { resolveDashboardDataPath } from './utils.js';
+
 // --- 状態管理 ---
 const state = {
     surveyId: null,
@@ -138,7 +140,8 @@ function normalizeOptions(options, questionId) {
 }
 
 async function loadSurveyData() {
-    const response = await fetch(`/data/surveys/${state.surveyId}.json`);
+    const dataPath = resolveDashboardDataPath(`surveys/${state.surveyId}.json`);
+    const response = await fetch(dataPath);
     if (!response.ok) {
         throw new Error(`アンケート定義ファイルが見つかりません (ID: ${state.surveyId})`);
     }


### PR DESCRIPTION
## Summary
- import the dashboard data path resolver into the survey answer script
- use the resolver when fetching survey definitions so subdirectory deployments load correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d61ef1d50832392ef4f9e1d247059)