### PR TITLE
fix: adjust 404 return link for subdirectory hosting

### DIFF
--- a/404.html
+++ b/404.html
@@ -145,7 +145,7 @@
       お探しのページは移動したか、削除された可能性があります。URLを再確認いただくか、以下のボタンからトップページへお戻りください。
     </p>
     <div class="actions">
-      <a class="primary-button" href="/index.html" aria-label="SPEED AD トップページに戻る">
+      <a class="primary-button" href="./index.html" aria-label="SPEED AD トップページに戻る">
         トップページへ戻る
       </a>
       <a class="contact-link" href="mailto:support@speed-ad.example.com">サポートに連絡する</a>


### PR DESCRIPTION
## Summary
- change the 404 page return button to use a relative link so it still points to the top page when hosted in a subdirectory

## Testing
- python -m http.server 8000 (open http://127.0.0.1:8000/SPPED-AD-TEST/404.html and verify the "トップページへ戻る" link navigates to http://127.0.0.1:8000/SPPED-AD-TEST/index.html)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d61f511948323a9c00f52241f6d81)