### PR TITLE
fix: normalize dashboard modal template paths

### DIFF
--- a/02_dashboard/src/accountInfoModal.js
+++ b/02_dashboard/src/accountInfoModal.js
@@ -1,5 +1,5 @@
 import { handleOpenModal, closeModal } from './modalHandler.js';
-import { showToast } from './utils.js';
+import { showToast, resolveDashboardAssetPath } from './utils.js';
 
 // ダミーユーザーデータ (本来はAPIから取得)
 // windowオブジェクトにアタッチすることで、HTMLのonclickから参照可能にする
@@ -30,7 +30,7 @@ window.dummyUserData = {
  * @param {object} userData 表示するユーザーデータ
  */
 export async function openAccountInfoModal(userData) {
-    await handleOpenModal('accountInfoModal', 'modals/accountInfoModal.html');
+    await handleOpenModal('accountInfoModal', resolveDashboardAssetPath('modals/accountInfoModal.html'));
     // モーダルがDOMにロードされた後、専用の初期化処理とデータ投入を行う
     initializeAccountInfoModalFunctionality(document.getElementById('accountInfoModal')); // モーダル要素を渡す
     populateAccountInfoModal(userData); // データ投入

--- a/02_dashboard/src/confirmationModal.js
+++ b/02_dashboard/src/confirmationModal.js
@@ -1,4 +1,5 @@
 import { handleOpenModal, closeModal } from './modalHandler.js';
+import { resolveDashboardAssetPath } from './utils.js';
 
 /**
  * Displays a confirmation modal and executes a callback on confirmation.
@@ -19,7 +20,7 @@ export function showConfirmationModal(message, onConfirm, options = {}) {
         prompt = null // New option for input field
     } = options;
 
-    handleOpenModal('confirmationModal', '/02_dashboard/modals/confirmationModal.html')
+    handleOpenModal('confirmationModal', resolveDashboardAssetPath('modals/confirmationModal.html'))
         .then(() => {
             const modal = document.getElementById('confirmationModal');
             const titleEl = document.getElementById('confirmationModalTitle');

--- a/02_dashboard/src/downloadOptionsModal.js
+++ b/02_dashboard/src/downloadOptionsModal.js
@@ -1,4 +1,5 @@
 import { handleOpenModal, closeModal } from './modalHandler.js';
+import { resolveDashboardAssetPath } from './utils.js';
 
 const DEFAULT_START_TIME = '00:00';
 const DEFAULT_END_TIME = '24:00';
@@ -134,7 +135,7 @@ function initializeDatepickers() {
  * @param {string} periodEnd End date for the survey period (YYYY-MM-DD).
  */
 export async function openDownloadModal(initialSelection, periodStart = '', periodEnd = '') {
-    await handleOpenModal('downloadOptionsModal', 'modals/downloadOptionsModal.html');
+    await handleOpenModal('downloadOptionsModal', resolveDashboardAssetPath('modals/downloadOptionsModal.html'));
 
     // Set checked states before initializing
     const periodAllRadio = document.getElementById('period_all');

--- a/02_dashboard/src/duplicateSurveyModal.js
+++ b/02_dashboard/src/duplicateSurveyModal.js
@@ -1,5 +1,5 @@
 import { handleOpenModal, closeModal } from './modalHandler.js';
-import { showToast } from './utils.js';
+import { showToast, resolveDashboardAssetPath } from './utils.js';
 
 // --- DOM Elements ---
 let modal;
@@ -124,7 +124,7 @@ const setupEventListeners = () => {
  * @param {object} survey The survey object to be duplicated.
  */
 export async function openDuplicateSurveyModal(survey) {
-    await handleOpenModal('duplicateSurveyModal', 'modals/duplicateSurveyModal.html');
+    await handleOpenModal('duplicateSurveyModal', resolveDashboardAssetPath('modals/duplicateSurveyModal.html'));
     
     initElements();
 

--- a/02_dashboard/src/groupEdit.js
+++ b/02_dashboard/src/groupEdit.js
@@ -1,4 +1,4 @@
-import { showToast } from './utils.js';
+import { showToast, resolveDashboardAssetPath } from './utils.js';
 import { showConfirmationModal } from './confirmationModal.js';
 import { handleOpenModal, closeModal } from './modalHandler.js';
 
@@ -351,7 +351,7 @@ function setupEventListeners() {
                 showToast('メンバーを削除しました。', 'success');
             });
         } else if (!target.closest('select, button, a')) {
-            handleOpenModal('memberDetailModal', 'modals/memberDetailModal.html').then(() => {
+            handleOpenModal('memberDetailModal', resolveDashboardAssetPath('modals/memberDetailModal.html')).then(() => {
                 if (member) populateMemberDetailModal(member);
             });
         }

--- a/02_dashboard/src/main.js
+++ b/02_dashboard/src/main.js
@@ -33,7 +33,7 @@ import { initializePage as initSpeedReviewPage } from './speed-review.js'; // Im
 import { initGroupEditPage } from './groupEdit.js';
 import { initPasswordChange } from './password_change.js';
 
-import { showToast, copyTextToClipboard, loadCommonHtml } from './utils.js';
+import { showToast, copyTextToClipboard, loadCommonHtml, resolveDashboardAssetPath } from './utils.js';
 
 function showTutorialResumeBanner() {
     if (document.getElementById('tutorialResumeBanner')) {
@@ -92,7 +92,7 @@ function showTutorialResumeBanner() {
 }
 
 function openNewSurveyModalWithSetup(afterOpen) {
-    handleOpenModal('newSurveyModal', 'modals/newSurveyModal.html', () => {
+    handleOpenModal('newSurveyModal', resolveDashboardAssetPath('modals/newSurveyModal.html'), () => {
         // Initialize flatpickr for the new range input
         const tomorrow = new Date();
         tomorrow.setHours(0, 0, 0, 0);

--- a/02_dashboard/src/speed-review.js
+++ b/02_dashboard/src/speed-review.js
@@ -1,5 +1,5 @@
 
-import { resolveDemoDataPath, resolveDashboardDataPath, showToast } from './utils.js';
+import { resolveDemoDataPath, resolveDashboardDataPath, resolveDashboardAssetPath, showToast } from './utils.js';
 import { speedReviewService } from './services/speedReviewService.js';
 import { populateTable, renderModalContent } from './ui/speedReviewRenderer.js';
 import { handleOpenModal } from './modalHandler.js';
@@ -119,7 +119,7 @@ function handleDetailClick(answerId) {
     if (item) {
         currentItemInModal = item;
         isModalInEditMode = false;
-        handleOpenModal('reviewDetailModalOverlay', 'modals/reviewDetailModal.html', () => {
+        handleOpenModal('reviewDetailModalOverlay', resolveDashboardAssetPath('modals/reviewDetailModal.html'), () => {
             renderModalContent(item, false);
             setupModalEventListeners();
         });

--- a/02_dashboard/src/surveyCreation.js
+++ b/02_dashboard/src/surveyCreation.js
@@ -14,7 +14,7 @@ import {
 } from './ui/surveyRenderer.js';
 import { initializeFab } from './ui/fab.js';
 import { initializeDatepickers } from './ui/datepicker.js';
-import { loadCommonHtml, showToast, resolveDashboardDataPath, resolveDemoDataPath } from './utils.js';
+import { loadCommonHtml, showToast, resolveDashboardDataPath, resolveDemoDataPath, resolveDashboardAssetPath } from './utils.js';
 import { showConfirmationModal } from './confirmationModal.js';
 
 // --- Global State ---
@@ -686,7 +686,7 @@ function updateAndRenderAll() {
         if (!qrButton.dataset.qrModalListenerAttached) {
             qrButton.addEventListener('click', () => {
                 if (qrButton.disabled) return;
-                handleOpenModal('qrCodeModal', 'modals/qrCodeModal.html', setupQrCodeModalListeners);
+                handleOpenModal('qrCodeModal', resolveDashboardAssetPath('modals/qrCodeModal.html'), setupQrCodeModalListeners);
             });
             qrButton.dataset.qrModalListenerAttached = 'true';
         }
@@ -1119,7 +1119,7 @@ async function initializePage() {
             loadCommonHtml('sidebar-placeholder', 'common/sidebar.html', initSidebarHandler),
             loadCommonHtml('footer-placeholder', 'common/footer.html', () => {
                 const btn = document.getElementById('openContactModalBtn');
-                if (btn) btn.addEventListener('click', () => handleOpenModal('contactModal', 'modals/contactModal.html'));
+                if (btn) btn.addEventListener('click', () => handleOpenModal('contactModal', resolveDashboardAssetPath('modals/contactModal.html')));
             })
         ]);
 
@@ -2230,7 +2230,7 @@ function attachPreviewListener() {
         previewBtn.addEventListener('click', () => {
             try {
                 localStorage.setItem('surveyPreviewData', JSON.stringify(surveyData));
-                handleOpenModal('surveyPreviewModal', 'modals/surveyPreviewModal.html', setupPreviewSwitcher);
+                handleOpenModal('surveyPreviewModal', resolveDashboardAssetPath('modals/surveyPreviewModal.html'), setupPreviewSwitcher);
             } catch (e) {
                 console.error('Failed to save preview data to localStorage', e);
                 showToast('プレビューの表示に失敗しました。', 'error');

--- a/02_dashboard/src/tableManager.js
+++ b/02_dashboard/src/tableManager.js
@@ -1,5 +1,5 @@
 import { showConfirmationModal } from './confirmationModal.js';
-import { showToast, copyTextToClipboard, resolveDashboardDataPath, debounce } from './utils.js';
+import { showToast, copyTextToClipboard, resolveDashboardDataPath, resolveDashboardAssetPath, debounce } from './utils.js';
 import { handleOpenModal } from './modalHandler.js';
 import { populateSurveyDetails } from './surveyDetailsModal.js';
 import { openDownloadModal } from './downloadOptionsModal.js';
@@ -219,14 +219,14 @@ function renderTableRows(surveysToRender) {
 
         row.querySelector('button[title="QRコードを表示"]').addEventListener('click', (e) => {
             e.stopPropagation();
-            handleOpenModal('qrCodeModal', 'modals/qrCodeModal.html');
+            handleOpenModal('qrCodeModal', resolveDashboardAssetPath('modals/qrCodeModal.html'));
         });
         
         row.addEventListener('click', (e) => {
             if (e.target.closest('button')) {
                 return;
             }
-            handleOpenModal('surveyDetailsModal', 'modals/surveyDetailsModal.html')
+            handleOpenModal('surveyDetailsModal', resolveDashboardAssetPath('modals/surveyDetailsModal.html'))
                 .then(() => {
                     populateSurveyDetails(survey);
                 })

--- a/02_dashboard/src/utils.js
+++ b/02_dashboard/src/utils.js
@@ -2,6 +2,7 @@
 let scrollPosition = 0; // Stores scroll position for `lockScroll`/`unlockScroll`
 let activeUIsCount = 0; // Tracks number of active UI overlays (modals, mobile sidebar)
 
+const DEFAULT_DASHBOARD_ROOT = '/02_dashboard';
 const DEFAULT_DATA_ROOT = '/data';
 function removeTrailingSlash(urlString) {
     return urlString.replace(/\/$/, '');
@@ -54,6 +55,15 @@ function resolveRepoBasePath() {
     return pathname.slice(0, markerIndex);
 }
 
+function getDashboardRoot() {
+    const basePath = resolveRepoBasePath();
+    if (!basePath) {
+        return DEFAULT_DASHBOARD_ROOT;
+    }
+
+    return `${basePath}${DEFAULT_DASHBOARD_ROOT}`;
+}
+
 function getDashboardDataRoot() {
     if (DASHBOARD_DATA_ROOT) {
         return DASHBOARD_DATA_ROOT;
@@ -77,6 +87,12 @@ function sanitizeRelativePath(relativePath) {
 export function resolveDashboardDataPath(relativePath) {
     const sanitized = sanitizeRelativePath(relativePath);
     const root = getDashboardDataRoot();
+    return sanitized ? `${root}/${sanitized}` : root;
+}
+
+export function resolveDashboardAssetPath(relativePath) {
+    const sanitized = sanitizeRelativePath(relativePath);
+    const root = getDashboardRoot();
     return sanitized ? `${root}/${sanitized}` : root;
 }
 


### PR DESCRIPTION
## Summary
- add resolveDashboardAssetPath helper to build modal URLs that respect subdirectory hosting
- update all modal openers to use the shared resolver, including the confirmation modal

## Testing
- not run (manual verification required)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d811256a08323a85fe159f865a468)