### PR TITLE
fix: ensure logout redirect works within repository scope

### DIFF
--- a/02_dashboard/src/sidebarHandler.js
+++ b/02_dashboard/src/sidebarHandler.js
@@ -295,7 +295,8 @@ function attachEventListeners() {
                 () => {
                     localStorage.clear();
                     sessionStorage.clear();
-                    window.location.href = '/index.html';
+                    const logoutRedirectUrl = new URL('../index.html', window.location.href);
+                    window.location.href = logoutRedirectUrl.toString();
                 },
                 'ログアウト'
             );


### PR DESCRIPTION
## Summary
- compute the logout redirect URL relative to the dashboard entry point so it works from GitHub Pages and local servers

## Testing
- not run (manual verification required)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142ca1c7c883239e794b39ef327479)