### PR TITLE
fix: use relative paths for dashboard assets

### DIFF
--- a/02_dashboard/src/faq.js
+++ b/02_dashboard/src/faq.js
@@ -1,3 +1,5 @@
+import { resolveDashboardDataPath } from './utils.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const faqApp = {
         elements: {
@@ -24,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
             this.state.isLoading = true;
             this.renderUI();
             try {
-                const response = await fetch('../data/faq.json');
+                const response = await fetch(resolveDashboardDataPath('faq.json'));
                 if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
                 this.state.allData = await response.json();
             } catch (e) {

--- a/02_dashboard/src/help-center.js
+++ b/02_dashboard/src/help-center.js
@@ -1,3 +1,5 @@
+import { resolveDashboardDataPath } from './utils.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const helpCenterApp = {
         elements: {
@@ -44,8 +46,8 @@ document.addEventListener('DOMContentLoaded', () => {
         async loadData() {
             try {
                 const [notificationsRes, articlesRes] = await Promise.all([
-                    fetch('../data/notifications.json'),
-                    fetch('../data/help_articles.json')
+                    fetch(resolveDashboardDataPath('notifications.json')),
+                    fetch(resolveDashboardDataPath('help_articles.json'))
                 ]);
                 if (!notificationsRes.ok) throw new Error('お知らせデータの読み込みに失敗しました。');
                 if (!articlesRes.ok) throw new Error('記事データの読み込みに失敗しました。');

--- a/02_dashboard/src/help-content.js
+++ b/02_dashboard/src/help-content.js
@@ -1,3 +1,5 @@
+import { resolveDashboardDataPath } from './utils.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const helpContentApp = {
         elements: {
@@ -21,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         async fetchFaqData() {
             try {
-                const response = await fetch('../data/help_articles.json');
+                const response = await fetch(resolveDashboardDataPath('help_articles.json'));
                 if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
                 this.state.faqData = await response.json();
             } catch (error) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,5 +41,5 @@
 
 ## 運用メモ
 - 共通ヘッダーやサイドバーなどの HTML は `02_dashboard/common/` から `loadCommonHtml(...)` で読み込む仕様です。`window.__COMMON_BASE_PATH` を必ず確認してください。
-- ダッシュボード用 JSON は `data/` 配下に統一されています。新規データは `resolveDashboardDataPath` を介して参照すること。
+- ダッシュボード用 JSON は リポジトリ直下の `data/` 配下に統一されています。新規データは `resolveDashboardDataPath` （`./` 起点の相対パスを返却）を介して参照すること。
 - 旧リポジトリから移管した添付ファイルは `docs/archive/` に退避済みです。再利用する場合は最新仕様と差異がないか確認してから復元してください。

--- a/docs/product/specs/12_dashboard_current_functional_requirements.md
+++ b/docs/product/specs/12_dashboard_current_functional_requirements.md
@@ -6,7 +6,7 @@
 - Login, admin, and other entry points are out of scope unless reused by the dashboard shell.
 
 ## Data Sources and Path Resolution
-- `02_dashboard/src/utils.js` exposes `resolveDashboardDataPath` and `resolveDemoDataPath` to translate relative requests into `/data/...` and `/data/demo_...`.
+- `02_dashboard/src/utils.js` exposes `resolveDashboardDataPath` and `resolveDemoDataPath` to translate relative requests into `./data/...` および `./data/demo_...`（必要に応じて `../` を積み上げる相対パス）。返却値はいずれも `.` で始まり、HTML 配信元に依存せず同階層・下位階層からデータが解決できる。
 - Primary datasets include `data/surveys/surveys-with-details.json` (table view and survey modal), `data/core/surveys.json` (per-survey settings), `data/core/invoices.json` (billing), and `data/core/groups.json` (sidebar context).
 - Sample responses and business-card payloads live under `data/demo_answers`, `data/demo_business-cards`, and `data/responses`; CSV paths are also supported by `speedReviewService`.
 - Write operations update in-memory arrays or `localStorage`; no server persistence is wired up in this codebase.
@@ -40,7 +40,7 @@
 - Detail modal supports view/edit modes, adapting controls for single-choice, multi-choice, and free-text questions; edits are applied to in-memory state and persisted only for the session.
 
 ### Graph Page (`graph-page.html`, `graph-page.js`)
-- Loads survey definitions and answers from `/data/demo_surveys` and `/data/demo_answers`.
+- Loads survey definitions and answers from paths resolved via `resolveDashboardDataPath`（例: `./data/demo_surveys`, `./data/demo_answers`）。
 - Optional date range filtering limits the dataset before aggregation.
 - Produces chart-ready data for single and multi-choice questions while ensuring that predefined options with zero responses still appear in the output.
 


### PR DESCRIPTION
## Summary
- align dashboard path utilities to return relative ./ or ../ prefixes and prevent double slashes when joining
- update FAQ and help center modules to resolve data files through the shared helpers
- refresh dashboard documentation to describe the relative data path behaviour

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69143c2e1dac832395b857bf0fe9a67f)