### PR TITLE
Fix admin sidebar active link resolution

### DIFF
--- a/03_admin/src/admin.js
+++ b/03_admin/src/admin.js
@@ -137,12 +137,19 @@ function handleResizeForSidebar() {
  * Sets the active state for the current page in the sidebar navigation.
  */
 function setActiveSidebarLink() {
-    const currentPage = window.location.pathname.split('/').pop();
+    const normalizedCurrentPath = window.location.pathname.replace(/\/index\.html$/, '/');
     const sidebarLinks = document.querySelectorAll('.admin-sidebar .nav-link');
-    
+
     sidebarLinks.forEach(link => {
-        const linkPage = link.getAttribute('href').split('/').pop();
-        if (linkPage === currentPage) {
+        link.classList.remove('active');
+
+        const href = link.getAttribute('href');
+        if (!href) {
+            return;
+        }
+
+        const linkPath = new URL(href, window.location.href).pathname.replace(/\/index\.html$/, '/');
+        if (linkPath === normalizedCurrentPath) {
             link.classList.add('active');
         }
     });


### PR DESCRIPTION
## Summary
- normalize sidebar link path matching to highlight only the active admin page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69364b225bc08323897634a88f552c10)