### PR TITLE
Add expired download modal and bypassable survey fixture

### DIFF
--- a/02_dashboard/modals/downloadExpiredModal.html
+++ b/02_dashboard/modals/downloadExpiredModal.html
@@ -1,0 +1,14 @@
+<div id="downloadExpiredModal" class="fixed inset-0 flex items-center justify-center p-4 modal-overlay hidden z-[60]" data-state="closed" aria-labelledby="downloadExpiredTitle" aria-describedby="downloadExpiredMessage">
+    <div class="bg-surface rounded-lg shadow-xl p-6 w-full max-w-md modal-content-transition" data-state="closed">
+        <div class="flex justify-between items-center mb-4">
+            <h3 id="downloadExpiredTitle" class="text-on-surface text-xl font-semibold">ダウンロードできません</h3>
+            <button class="text-on-surface-variant hover:text-on-surface" aria-label="モーダルを閉じる" data-modal-close="downloadExpiredModal">
+                <span class="material-icons">close</span>
+            </button>
+        </div>
+        <p id="downloadExpiredMessage" class="text-on-surface-variant">ダウンロード期限を過ぎています。データを取得できる期間をご確認ください。</p>
+        <div class="flex justify-end gap-3 pt-6">
+            <button class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold leading-normal transition-colors" data-modal-close="downloadExpiredModal" aria-label="閉じる">閉じる</button>
+        </div>
+    </div>
+</div>

--- a/02_dashboard/src/tableManager.js
+++ b/02_dashboard/src/tableManager.js
@@ -110,7 +110,8 @@ export async function fetchSurveyData() {
             'sv_0001_25044', 'sv_0001_25045', 'sv_0001_25047', 'sv_0001_25049', 'sv_0001_25050',
             'sv_0001_25051', 'sv_0001_25052', 'sv_0001_25053', 'sv_0001_25054', 'sv_0001_25055',
             'sv_0001_25056', 'sv_0001_25057', 'sv_0001_25058', 'sv_0001_25059', 'sv_0001_25060',
-            'sv_0001_25061', 'sv_0001_25062', 'sv_0001_25063', 'sv_0001_25064', 'sv_0001_25065'
+            'sv_0001_25061', 'sv_0001_25062', 'sv_0001_25063', 'sv_0001_25064', 'sv_0001_25065',
+            'sv_0001_99099'
         ];
         fetchStats.totalCount = surveyIds.length;
         const surveyPromises = surveyIds.map(async id => {
@@ -263,11 +264,11 @@ function renderTableRows(surveysToRender) {
         const downloadButton = row.querySelector('button[title="データダウンロード"]');
         if (downloadButton) {
             if (lifecycleMeta.isDownloadable) {
-                downloadButton.classList.remove('opacity-50', 'pointer-events-none', 'cursor-not-allowed');
+                downloadButton.classList.remove('opacity-50', 'cursor-not-allowed');
                 downloadButton.removeAttribute('aria-disabled');
                 downloadButton.title = 'データダウンロード';
             } else {
-                downloadButton.classList.add('opacity-50', 'pointer-events-none', 'cursor-not-allowed');
+                downloadButton.classList.add('opacity-50', 'cursor-not-allowed');
                 downloadButton.setAttribute('aria-disabled', 'true');
                 downloadButton.title = statusTitle;
             }
@@ -292,6 +293,13 @@ function renderTableRows(surveysToRender) {
             downloadButton.addEventListener('click', (e) => {
                 e.stopPropagation();
                 if (!lifecycleMeta.isDownloadable) {
+                    if (lifecycleMeta.status === USER_STATUSES.DOWNLOAD_CLOSED) {
+                        handleOpenModal(
+                            'downloadExpiredModal',
+                            resolveDashboardAssetPath('modals/downloadExpiredModal.html')
+                        );
+                        return;
+                    }
                     showToast('名刺データは現在ダウンロードできません。', 'info');
                     return;
                 }

--- a/data/demo_surveys/sv_0001_99099.json
+++ b/data/demo_surveys/sv_0001_99099.json
@@ -1,0 +1,49 @@
+{
+    "id": "sv_0001_99099",
+    "groupId": "GROUP-DEMO",
+    "name": {
+        "ja": "機能確認用アンケート",
+        "en": "Feature Verification Survey"
+    },
+    "displayTitle": {
+        "ja": "機能確認用アンケート",
+        "en": "Feature Verification Survey"
+    },
+    "description": {
+        "ja": "ダウンロード期限の動作確認に用いる特別なアンケートです。",
+        "en": "A special survey for validating download expiry behavior."
+    },
+    "memo": "ダウンロード期限を無視する特例設定付き。",
+    "status": "データ精査完了",
+    "answerCount": 12,
+    "realtimeAnswers": 0,
+    "periodStart": "2024-01-01",
+    "periodEnd": "2024-01-31",
+    "dataCompletionDate": "2024-02-05",
+    "plan": "Standard",
+    "deadline": "2024-03-31",
+    "bypassDownloadDeadline": true,
+    "bizcardEnabled": true,
+    "bizcardRequest": 15,
+    "bizcardCompletionCount": 15,
+    "thankYouEmailSettings": "自動送信",
+    "details": [
+        {
+            "id": "q1",
+            "text": "Q.01_確認担当者名",
+            "type": "free_text"
+        },
+        {
+            "id": "q2",
+            "text": "Q.02_確認目的",
+            "type": "single_choice",
+            "options": ["リリース確認", "デモ", "QA検証", "その他"]
+        },
+        {
+            "id": "q3",
+            "text": "Q.03_備考",
+            "type": "free_text"
+        }
+    ],
+    "createdAt": "2024-01-01T00:00:00+09:00"
+}

--- a/data/surveys/sv_0001_99099.json
+++ b/data/surveys/sv_0001_99099.json
@@ -1,0 +1,49 @@
+{
+    "id": "sv_0001_99099",
+    "groupId": "GROUP-DEMO",
+    "name": {
+        "ja": "機能確認用アンケート",
+        "en": "Feature Verification Survey"
+    },
+    "displayTitle": {
+        "ja": "機能確認用アンケート",
+        "en": "Feature Verification Survey"
+    },
+    "description": {
+        "ja": "ダウンロード期限の動作確認に用いる特別なアンケートです。",
+        "en": "A special survey for validating download expiry behavior."
+    },
+    "memo": "ダウンロード期限を無視する特例設定付き。",
+    "status": "データ精査完了",
+    "answerCount": 12,
+    "realtimeAnswers": 0,
+    "periodStart": "2024-01-01",
+    "periodEnd": "2024-01-31",
+    "dataCompletionDate": "2024-02-05",
+    "plan": "Standard",
+    "deadline": "2024-03-31",
+    "bypassDownloadDeadline": true,
+    "bizcardEnabled": true,
+    "bizcardRequest": 15,
+    "bizcardCompletionCount": 15,
+    "thankYouEmailSettings": "自動送信",
+    "details": [
+        {
+            "id": "q1",
+            "text": "Q.01_確認担当者名",
+            "type": "free_text"
+        },
+        {
+            "id": "q2",
+            "text": "Q.02_確認目的",
+            "type": "single_choice",
+            "options": ["リリース確認", "デモ", "QA検証", "その他"]
+        },
+        {
+            "id": "q3",
+            "text": "Q.03_備考",
+            "type": "free_text"
+        }
+    ],
+    "createdAt": "2024-01-01T00:00:00+09:00"
+}


### PR DESCRIPTION
## Summary
- show a modal explaining the download period has expired when clicking the inactive data download button
- remove pointer-event blocking and add a dedicated expiry modal for clearer feedback
- add a special feature-verification survey fixture that bypasses download deadline logic for demos

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fdbb83c4c83239131da65c97cb9f7)