### PR TITLE
update: survey details modal label and value

### DIFF
--- a/02_dashboard/modals/surveyDetailsModal.html
+++ b/02_dashboard/modals/surveyDetailsModal.html
@@ -1,11 +1,15 @@
-<div id="surveyDetailsModal" class="fixed inset-0 flex items-center justify-center p-4 modal-overlay hidden z-[60]" data-state="closed">
-    <div class="bg-surface rounded-lg shadow-xl p-6 w-full max-w-3xl flex flex-col modal-content-transition max-h-[90vh]" data-state="closed">
+<div id="surveyDetailsModal" class="fixed inset-0 flex items-center justify-center p-4 modal-overlay hidden z-[60]"
+    data-state="closed">
+    <div class="bg-surface rounded-lg shadow-xl p-6 w-full max-w-3xl flex flex-col modal-content-transition max-h-[90vh]"
+        data-state="closed">
         <div class="flex justify-between items-center mb-6 flex-shrink-0">
             <div class="flex items-center gap-3">
                 <h3 id="surveyDetailName" class="text-on-surface text-xl font-semibold"></h3>
-                <span id="surveyDetailStatusBadge" class="inline-flex items-center rounded-full text-xs px-2 py-1"></span>
+                <span id="surveyDetailStatusBadge"
+                    class="inline-flex items-center rounded-full text-xs px-2 py-1"></span>
             </div>
-            <button class="text-on-surface-variant hover:text-on-surface" id="closeSurveyDetailsModalBtn" aria-label="モーダルを閉じる">
+            <button class="text-on-surface-variant hover:text-on-surface" id="closeSurveyDetailsModalBtn"
+                aria-label="モーダルを閉じる">
                 <span class="material-icons">close</span>
             </button>
         </div>
@@ -30,25 +34,32 @@
                     </div>
                     <div class="md:col-span-2 input-group">
                         <p id="detail_surveyNameInternal_view" class="text-on-surface text-base view-mode"></p>
-                        <input type="text" id="detail_surveyNameInternal" name="name" class="input-field edit-mode hidden">
+                        <input type="text" id="detail_surveyNameInternal" name="name"
+                            class="input-field edit-mode hidden">
                         <label for="detail_surveyNameInternal" class="input-label font-bold">アンケート名（社内管理用）</label>
-                        <button type="button" class="help-icon-button material-icons" data-tooltip-id="survey-name-tooltip" aria-label="アンケート名と表示タイトルの違いを表示">help_outline</button>
+                        <button type="button" class="help-icon-button material-icons"
+                            data-tooltip-id="survey-name-tooltip" aria-label="アンケート名と表示タイトルの違いを表示">help_outline</button>
                         <div id="survey-name-tooltip" class="help-popover hidden" role="tooltip">
                             <p class="text-xs leading-snug text-on-surface-variant">社内向けの管理名称です。回答者には表示されません。</p>
                         </div>
                     </div>
                     <div class="md:col-span-2 input-group">
                         <p id="detail_displayTitle_view" class="text-on-surface text-base view-mode"></p>
-                        <input type="text" id="detail_displayTitle" name="displayTitle" class="input-field edit-mode hidden">
+                        <input type="text" id="detail_displayTitle" name="displayTitle"
+                            class="input-field edit-mode hidden">
                         <label for="detail_displayTitle" class="input-label font-bold">表示タイトル</label>
-                        <button type="button" class="help-icon-button material-icons" data-tooltip-id="display-title-tooltip" aria-label="表示タイトルの説明を表示">help_outline</button>
+                        <button type="button" class="help-icon-button material-icons"
+                            data-tooltip-id="display-title-tooltip" aria-label="表示タイトルの説明を表示">help_outline</button>
                         <div id="display-title-tooltip" class="help-popover hidden" role="tooltip">
-                            <p class="text-xs leading-snug text-on-surface-variant">回答者に表示されるタイトルです。イベント名など外部向けの名称を設定してください。</p>
+                            <p class="text-xs leading-snug text-on-surface-variant">
+                                回答者に表示されるタイトルです。イベント名など外部向けの名称を設定してください。</p>
                         </div>
                     </div>
                     <div class="md:col-span-2 input-group">
-                        <p id="detail_surveyMemo_view" class="text-on-surface text-base whitespace-pre-wrap view-mode"></p>
-                        <textarea id="detail_surveyMemo" name="memo" class="input-field edit-mode hidden" rows="3"></textarea>
+                        <p id="detail_surveyMemo_view" class="text-on-surface text-base whitespace-pre-wrap view-mode">
+                        </p>
+                        <textarea id="detail_surveyMemo" name="memo" class="input-field edit-mode hidden"
+                            rows="3"></textarea>
                         <label for="detail_surveyMemo" class="input-label font-bold">メモ</label>
                     </div>
                     <div class="md:col-span-2">
@@ -78,7 +89,8 @@
                         <p id="detail_answerCount" class="text-on-surface text-base"></p>
                     </div>
                     <div>
-                        <label id="detail_billingAmount_label" class="text-on-surface-variant text-sm font-bold">見込み請求額</label>
+                        <label id="detail_billingAmount_label"
+                            class="text-on-surface-variant text-sm font-bold">見込み請求額</label>
                         <p id="detail_estimatedBillingAmount_view" class="text-on-surface text-base view-mode"></p>
                     </div>
                     <div>
@@ -101,11 +113,12 @@
                         <p id="detail_bizcardEnabled_view" class="text-on-surface text-base"></p>
                     </div>
                     <div>
-                        <label class="text-on-surface-variant text-sm font-bold">名刺データ化件数</label>
+                        <label class="text-on-surface-variant text-sm font-bold">名刺見込み件数</label>
                         <p id="detail_bizcardCompletionCount" class="text-on-surface text-base"></p>
                     </div>
                     <div class="md:col-span-2">
-                        <button type="button" id="goToBizcardSettingsBtn" class="w-full button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold">名刺データ化設定へ</button>
+                        <button type="button" id="goToBizcardSettingsBtn"
+                            class="w-full button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold">名刺データ化設定へ</button>
                     </div>
                 </div>
             </div>
@@ -118,7 +131,8 @@
                         <p id="detail_thankYouEmailSettings_view" class="text-on-surface text-base"></p>
                     </div>
                     <div class="md:col-span-2">
-                        <button type="button" id="goToThankYouEmailSettingsBtn" class="w-full button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold">お礼メール設定へ</button>
+                        <button type="button" id="goToThankYouEmailSettingsBtn"
+                            class="w-full button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold">お礼メール設定へ</button>
                     </div>
                 </div>
             </div>
@@ -127,12 +141,16 @@
             <div class="space-y-4">
                 <h4 class="text-on-surface text-lg font-semibold border-b border-outline-variant pb-2">アンケートアクセス情報</h4>
                 <div class="input-group">
-                    <input type="text" id="detail_surveyUrl" readonly class="input-field cursor-pointer" placeholder=" ">
+                    <input type="text" id="detail_surveyUrl" readonly class="input-field cursor-pointer"
+                        placeholder=" ">
                     <label for="detail_surveyUrl" class="input-label font-bold">アンケートURL</label>
                 </div>
                 <div class="text-center">
-                    <img id="detail_qrCodeImage" alt="QR Code" class="mx-auto mb-4 border border-outline-variant p-2 rounded" />
-                    <button type="button" id="downloadQrCodeBtn" class="button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold leading-normal transition-colors w-full" aria-label="QRコードをダウンロード">
+                    <img id="detail_qrCodeImage" alt="QR Code"
+                        class="mx-auto mb-4 border border-outline-variant p-2 rounded" />
+                    <button type="button" id="downloadQrCodeBtn"
+                        class="button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold leading-normal transition-colors w-full"
+                        aria-label="QRコードをダウンロード">
                         <span class="material-icons text-xl">download</span>
                         QRコードをダウンロード
                     </button>
@@ -141,16 +159,28 @@
         </form>
         <div id="viewModeButtons" class="flex justify-end gap-3 pt-4 flex-shrink-0">
             <div class="mr-auto">
-                <button id="deleteSurveyBtn" class="bg-red-500 text-white py-2 px-4 rounded-md shadow-sm text-sm font-semibold" type="button">アンケートを削除</button>
+                <button id="deleteSurveyBtn"
+                    class="bg-red-500 text-white py-2 px-4 rounded-md shadow-sm text-sm font-semibold"
+                    type="button">アンケートを削除</button>
             </div>
-            <button id="editSurveyBtn" class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold" type="button">編集</button>
-            <button id="goToSpeedReviewBtn" class="button-secondary py-2 px-4 rounded-md font-semibold" type="button">SPEEDレビュー</button>
-            <button id="detailDownloadBtn" class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold" type="button">データダウンロード</button>
-            <button class="button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold" id="footerCloseSurveyDetailsModalBtn" type="button">閉じる</button>
+            <button id="editSurveyBtn"
+                class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold"
+                type="button">編集</button>
+            <button id="goToSpeedReviewBtn" class="button-secondary py-2 px-4 rounded-md font-semibold"
+                type="button">SPEEDレビュー</button>
+            <button id="detailDownloadBtn"
+                class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold"
+                type="button">データダウンロード</button>
+            <button class="button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold"
+                id="footerCloseSurveyDetailsModalBtn" type="button">閉じる</button>
         </div>
         <div id="editModeButtons" class="hidden justify-end gap-3 pt-4 flex-shrink-0">
-            <button id="cancelEditBtn" class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold" type="button">キャンセル</button>
-            <button id="saveSurveyBtn" class="button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold" type="button">保存</button>
+            <button id="cancelEditBtn"
+                class="bg-secondary-container text-on-secondary-container py-2 px-4 rounded-md shadow-sm text-sm font-semibold"
+                type="button">キャンセル</button>
+            <button id="saveSurveyBtn"
+                class="button-primary text-on-primary py-2 px-4 rounded-md shadow-sm text-sm font-semibold"
+                type="button">保存</button>
         </div>
     </div>
 </div>

--- a/02_dashboard/src/surveyDetailsModal.js
+++ b/02_dashboard/src/surveyDetailsModal.js
@@ -222,7 +222,7 @@ function handleSaveSurvey() {
     updateSurveyData(newSurveyData);
 
     showToast('アンケート情報を保存しました！', 'success');
-    
+
 }
 
 function handleDetailDownload() {
@@ -252,7 +252,7 @@ export function populateSurveyDetails(survey) {
     // --- Get All View and Edit Elements ---
     const surveyDetailName = document.getElementById('surveyDetailName');
     const surveyDetailStatusBadge = document.getElementById('surveyDetailStatusBadge');
-    
+
     // View mode elements
     const detail_surveyId_view = document.getElementById('detail_surveyId');
     const detail_plan_view = document.getElementById('detail_plan_view');
@@ -320,7 +320,7 @@ export function populateSurveyDetails(survey) {
         ? `¥${billingAmountValue.toLocaleString()}`
         : '―';
     detail_bizcardEnabled_view.textContent = survey.bizcardEnabled ? '利用する' : '利用しない';
-    detail_bizcardCompletionCount_view.textContent = survey.bizcardEnabled ? `${survey.bizcardCompletionCount || 0}件` : 'N/A';
+    detail_bizcardCompletionCount_view.textContent = survey.bizcardEnabled ? `${survey.bizcardRequest || 0}件` : 'N/A';
     detail_thankYouEmailSettings_view.textContent = survey.thankYouEmailSettings || '設定なし';
 
     // Non-editable fields
@@ -329,7 +329,7 @@ export function populateSurveyDetails(survey) {
     detail_qrCodeImage.src = `sample_qr.png`; // survey.id を使って動的に生成
 
     // --- Reset to View Mode --- 
-    
+
 
     // 編集ボタンの表示/非表示をステータスに基づいて制御
     const editSurveyBtn = modal.querySelector('#editSurveyBtn');

--- a/docs/templates/issue_body.md
+++ b/docs/templates/issue_body.md
@@ -1,22 +1,14 @@
-### Pre-investigation Summary
-The user reported that the help tooltips in the "New Survey Modal" are not working, although the "Duplicate Survey Modal" ones are.
-Investigation revealed that the "New Survey" button in `main.js` calls `handleOpenModal` directly, bypassing `openNewSurveyModalWithSetup` which contains the logic for initializing the help popovers (and the date picker).
+### 概要
+アンケート詳細モーダルの表示項目を修正します。
 
-**Files to be changed:**
-- `02_dashboard/src/main.js`: Update the event listener for `#openNewSurveyModalBtn` to call `openNewSurveyModalWithSetup()` instead of `handleOpenModal(...)`.
+### 変更点
+1. **「名刺データ化件数」のラベル変更**
+   - 変更前: 名刺データ化件数
+   - 変更後: 名刺見込み件数
 
-### Contribution to Project Goals
-Ensures the New Survey Modal is fully initialized with all required functionality (help tooltips, date pickers, validation).
+2. **表示する数値の変更**
+   - 変更前: `bizcardCompletionCount`（データ化完了件数）
+   - 変更後: `bizcardRequest`（名刺データ化設定画面で入力された見込み件数）
 
-### Overview of Changes
-- Change the click handler for `#openNewSurveyModalBtn` in `main.js` to invoke the setup function.
-
-### Specific Work Content for Each File
-- `02_dashboard/src/main.js`:
-    - Locate the event listener for `openNewSurveyModalBtn`.
-    - Change the callback to call `openNewSurveyModalWithSetup()`.
-
-### Definition of Done
-- [ ] Clicking "Create New Survey" opens the modal.
-- [ ] value help icons work (popovers appear).
-- [ ] Date picker works (as it was also in that setup function).
+### 目的
+ユーザーが設定した名刺データ化の見込み件数を詳細画面で確認できるようにするため。

--- a/docs/templates/issue_comment_body.md
+++ b/docs/templates/issue_comment_body.md
@@ -3,23 +3,35 @@
 To resolve this Issue, I will proceed with the implementation according to the following plan.
 
 #### 1. **Pre-investigation Summary**
-- Confirmed `openNewSurveyModalBtn` click listener bypasses setup logic.
+- **Current State**:
+    - `02_dashboard/modals/surveyDetailsModal.html`: Label is "名刺データ化件数" (line 104).
+    - `02_dashboard/src/surveyDetailsModal.js`: Displays `survey.bizcardCompletionCount` (line 323).
+- **Goal**:
+    - Change label to "名刺見込み件数".
+    - Display `survey.bizcardRequest` instead of completion count. Note that `bizcardRequest` is already present in the survey data and logic (lines 282, 381 in bizcardSettings.js logic confirm usage, and line 215 in surveyDetailsModal.js preserves it).
 
 **Files to be changed:**
-- `02_dashboard/src/main.js`
+- `02_dashboard/modals/surveyDetailsModal.html`
+- `02_dashboard/src/surveyDetailsModal.js`
 
 #### 2. **Contribution to Project Goals**
-- Fixes bug where new features (help icons) were not active.
+- Aligns the detailed view with the user's input in the settings, providing clarity on the *requested* volume rather than just the *completed* volume, which might be N/A or zero initially.
 
 #### 3. **Overview of Changes**
-- Redirect the "New Survey" button click to the proper setup function.
+- **HTML**: Update the label text.
+- **JS**: Update the `populateSurveyDetails` function to map the text content of the target element to `survey.bizcardRequest`.
 
 #### 4. **Specific Work Content for Each File**
-- `02_dashboard/src/main.js`:
-    - Replace `handleOpenModal(...)` with `openNewSurveyModalWithSetup()` inside the `openNewSurveyModalBtn` click listener.
+- `02_dashboard/modals/surveyDetailsModal.html`:
+    - Change `<label>` text from "名刺データ化件数" to "名刺見込み件数".
+- `02_dashboard/src/surveyDetailsModal.js`:
+    - In `populateSurveyDetails`, change `detail_bizcardCompletionCount_view.textContent` assignment.
+    - It should display `${survey.bizcardRequest || 0}件` if enabled, otherwise 'N/A' (or keep existing logic for "utilize/not utilize" check).
 
 #### 5. **Definition of Done**
-- [ ] New Survey Modal help icons toggle popovers correctly.
+- [ ] Label in Survey Details Modal says "名刺見込み件数".
+- [ ] Value displayed matches the input form value (bizcardRequest).
+- [ ] `GEMINI.md` workflow is followed.
 
 ---
 If you approve, please reply to this comment with "Approve".


### PR DESCRIPTION
Closes #155

## 概要 (Overview)
アンケート詳細モーダルの名刺データ化に関する表示を修正しました。

## 主な変更点 (Key Changes)
- **`02_dashboard/modals/surveyDetailsModal.html`**:
    - ラベルを「名刺データ化件数」から「名刺見込み件数」に変更しました。
- **`02_dashboard/src/surveyDetailsModal.js`**:
    - 表示する値を「データ化完了件数（`bizcardCompletionCount`）」から「名刺見込み件数（`bizcardRequest`）」に変更しました。

## チェックリスト (Checklist)
- [x] ラベルが「名刺見込み件数」になっていることを確認
- [x] 表示される数値が設定画面での入力値（`bizcardRequest`）と一致していることを確認
- [x] `GEMINI.md`のワークフローに従っている
