### PR TITLE
fix(invoice): strongly reduce padding and min-height to prevent pdf overflow

### DIFF
--- a/02_dashboard/src/invoiceDetail.js
+++ b/02_dashboard/src/invoiceDetail.js
@@ -39,15 +39,20 @@ export async function initInvoiceDetailPage() {
         originalInfo.push({
           marginBottom: sheet.style.marginBottom,
           boxShadow: sheet.style.boxShadow,
-          minHeight: sheet.style.minHeight
+          minHeight: sheet.style.minHeight,
+          padding: sheet.style.padding
         });
         // @ts-ignore
         sheet.style.marginBottom = '0';
         // @ts-ignore
         sheet.style.boxShadow = 'none';
-        // Reduce min-height slightly to ensure it fits safely within 297mm without triggering overflow
+
+        // Aggressively reduce min-height and padding to ensure it fits safely within A4
+        // The original 297mm often triggers page breaks due to slight rendering differences
         // @ts-ignore
-        sheet.style.minHeight = '295mm';
+        sheet.style.minHeight = '275mm';
+        // @ts-ignore
+        sheet.style.padding = '10mm 15mm'; // Reduce vertical padding
       });
 
       const opt = {
@@ -70,6 +75,8 @@ export async function initInvoiceDetailPage() {
           sheet.style.boxShadow = originalInfo[i].boxShadow;
           // @ts-ignore
           sheet.style.minHeight = originalInfo[i].minHeight;
+          // @ts-ignore
+          sheet.style.padding = originalInfo[i].padding;
         });
       }).catch(err => {
         console.error('PDF generation failed:', err);
@@ -82,6 +89,8 @@ export async function initInvoiceDetailPage() {
           sheet.style.boxShadow = originalInfo[i].boxShadow;
           // @ts-ignore
           sheet.style.minHeight = originalInfo[i].minHeight;
+          // @ts-ignore
+          sheet.style.padding = originalInfo[i].padding;
         });
       });
     });


### PR DESCRIPTION
Closes #161

## 概要 (Overview)
請求書PDF生成時にページ下部がはみ出し、2枚目に見切れてしまう問題に対して、より安全なマージン確保のための再修正を行いました。

## 修正内容 (Changes)
- **PDF生成時の`min-height`と`padding`の大幅な削減**
    - `min-height` を `295mm` から **`275mm`** まで縮小し、A4サイズ(297mm)に対する余裕を20mm以上確保しました。
    - 上下の `padding` を `15mm` から **`10mm`** に一時的に変更し、コンテンツエリア全体を縮小しました。
    - これにより、ブラウザのレンダリングや `html2canvas` の計算誤差が生じても、確実に1ページ内に収まるようになります。

## この修正で期待される動作
ブラウザ上での見た目（余白多め）とは若干異なりますが（PDF生成時のみ余白が少し狭くなる）、確実に1ページに収まり「見切れ」や「不要な2ページ目」が発生しなくなります。

## チェックリスト (Checklist)
- [x] PDF生成時のみスタイルが変更され、終了後に元に戻ることを確認
- [x] 大きな安全マージンを設けたことによるオーバーフロー防止
- [x] `GEMINI.md`のワークフローに従っている
