### PR TITLE
fix(invoice): global row compression and strict css page breaks

### DIFF
--- a/02_dashboard/src/invoiceDetail.js
+++ b/02_dashboard/src/invoiceDetail.js
@@ -34,21 +34,22 @@ export async function initInvoiceDetailPage() {
       const originalContainerWidth = element.style.width;
       element.style.width = '210mm'; // Force exactly A4 width
 
-      sheets.forEach(sheet => {
+      sheets.forEach((sheet, index) => {
         // @ts-ignore
         originalInfo.push({
           marginBottom: sheet.style.marginBottom,
           boxShadow: sheet.style.boxShadow,
           minHeight: sheet.style.minHeight,
           height: sheet.style.height,
-          padding: sheet.style.padding
+          padding: sheet.style.padding,
+          pageBreakAfter: sheet.style.pageBreakAfter
         });
         // @ts-ignore
         sheet.style.marginBottom = '0';
         // @ts-ignore
         sheet.style.boxShadow = 'none';
 
-        // REMOVE min-height entirely to let content dictate size.
+        // Remove min-height / height constraints
         // @ts-ignore
         sheet.style.minHeight = 'auto';
         // @ts-ignore
@@ -56,16 +57,27 @@ export async function initInvoiceDetailPage() {
         // @ts-ignore
         sheet.style.padding = '10mm 15mm';
 
-        // Explicitly compress row height on Page 1 to ensure 20 rows fit easily
-        if (sheet.classList.contains('page-1')) {
-          const rows = sheet.querySelectorAll('td');
-          rows.forEach(td => {
-            // @ts-ignore
-            td.dataset.originalHeight = td.style.height;
-            // @ts-ignore
-            td.style.height = '20px'; // Force compressed height (default was 24px)
-          });
+        // STRICT PAGE BREAK MANAGEMENT
+        if (index < sheets.length - 1) {
+          // @ts-ignore
+          sheet.style.pageBreakAfter = 'always';
+        } else {
+          // @ts-ignore
+          sheet.style.pageBreakAfter = 'auto';
         }
+
+        // GLOBAL ROW COMPRESSION (All pages)
+        // Compressing to 18px ensures valid fit even with font updates or rendering shifts.
+        const rows = sheet.querySelectorAll('td');
+        rows.forEach(td => {
+          // @ts-ignore
+          if (!td.dataset.originalHeight) {
+            // @ts-ignore
+            td.dataset.originalHeight = td.style.height || '';
+          }
+          // @ts-ignore
+          td.style.height = '18px';
+        });
       });
 
       const opt = {
@@ -92,20 +104,21 @@ export async function initInvoiceDetailPage() {
           sheet.style.height = originalInfo[i].height;
           // @ts-ignore
           sheet.style.padding = originalInfo[i].padding;
+          // @ts-ignore
+          sheet.style.pageBreakAfter = originalInfo[i].pageBreakAfter;
 
-          if (sheet.classList.contains('page-1')) {
-            const rows = sheet.querySelectorAll('td');
-            rows.forEach(td => {
+          // Restore row heights
+          const rows = sheet.querySelectorAll('td');
+          rows.forEach(td => {
+            // @ts-ignore
+            if (td.dataset.originalHeight !== undefined) {
               // @ts-ignore
-              if (td.dataset.originalHeight) {
-                // @ts-ignore
-                td.style.height = td.dataset.originalHeight;
-              } else {
-                // @ts-ignore
-                td.style.height = '';
-              }
-            });
-          }
+              td.style.height = td.dataset.originalHeight;
+            } else {
+              // @ts-ignore
+              td.style.height = '';
+            }
+          });
         });
       }).catch(err => {
         console.error('PDF generation failed:', err);
@@ -122,20 +135,21 @@ export async function initInvoiceDetailPage() {
           sheet.style.height = originalInfo[i].height;
           // @ts-ignore
           sheet.style.padding = originalInfo[i].padding;
+          // @ts-ignore
+          sheet.style.pageBreakAfter = originalInfo[i].pageBreakAfter;
 
-          if (sheet.classList.contains('page-1')) {
-            const rows = sheet.querySelectorAll('td');
-            rows.forEach(td => {
+          // Restore row heights
+          const rows = sheet.querySelectorAll('td');
+          rows.forEach(td => {
+            // @ts-ignore
+            if (td.dataset.originalHeight !== undefined) {
               // @ts-ignore
-              if (td.dataset.originalHeight) {
-                // @ts-ignore
-                td.style.height = td.dataset.originalHeight;
-              } else {
-                // @ts-ignore
-                td.style.height = '';
-              }
-            });
-          }
+              td.style.height = td.dataset.originalHeight;
+            } else {
+              // @ts-ignore
+              td.style.height = '';
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
Closes #165

## 概要
請求書PDFにおいて「1ページしかないのに2ページ目（白紙）が生成される」「2ページ目のページ番号がはみ出て3ページ目に移る」という問題に対する、より強力な修正です。

## 修正内容
1.  **全ページへの行圧縮適用**
    - 以前は1ページ目のみに行っていた行の高さ圧縮（`td` 要素の高さ調整）を、**すべてのページ**に適用するように変更しました。
    - 高さを `18px` (前回よりさらに縮小) に強制し、ブラウザのレンダリング誤差を吸収できる十分な余白を確保しました。
2.  **`page-break-after` の厳密な制御**
    - JavaScriptで、最後のページ以外のすべてのページ（`.invoice-sheet`）に `page-break-after: always` を動的に付与し、最後のページには `auto` を設定することで、`html2pdf` の自動改ページ機能に頼らず、意図的な改ページのみを行うように制御しました。

## 期待される効果
- コンテンツ全体の縦幅が大幅に圧縮されるため、A4サイズの境界を越えることが物理的に無くなります。
- `page-break-after` の制御により、コンテンツ終了直後の不要な改ページ（白紙生成）を防ぎます。
- 2ページ目のページ番号はみ出しも、行圧縮により解消されます。

## チェックリスト
- [x] 全ページの行圧縮ロジック実装
- [x] CSSページブレイクの動的制御
- [x] ワークフロー遵守
