### PR TITLE
fix(invoice): force overflow hidden and cap max-height to eliminate blank pages

### DIFF
--- a/02_dashboard/src/invoiceDetail.js
+++ b/02_dashboard/src/invoiceDetail.js
@@ -52,6 +52,8 @@ export async function initInvoiceDetailPage() {
           padding: sheet.style.padding,
           position: sheet.style.position,
           pageBreakAfter: sheet.style.pageBreakAfter,
+          overflow: sheet.style.overflow,
+          maxHeight: sheet.style.maxHeight,
           pageNumEl: pageNumEl,
           originalPageNumStyle: originalPageNumStyle
         });
@@ -66,20 +68,29 @@ export async function initInvoiceDetailPage() {
         // @ts-ignore
         sheet.style.height = 'auto';
 
+        // FORCE overflow hidden to clip any invisible "white" content leaking out
+        // @ts-ignore
+        sheet.style.overflow = 'hidden';
+
+        // FORCE massive safety buffer by capping max-height well below A4 (297mm)
+        // 270mm should be perfectly safe even with margins
+        // @ts-ignore
+        sheet.style.maxHeight = '275mm';
+
         // Use relative positioning for the sheet to anchor absolute children
         // @ts-ignore
         sheet.style.position = 'relative';
 
-        // Set padding: Top 5mm, Sides 15mm, Bottom 20mm (space for footer)
+        // Set padding: Top 5mm, Sides 15mm, Bottom 5mm (Reduced bottom padding to prevent push)
         // @ts-ignore
-        sheet.style.padding = '5mm 15mm 20mm 15mm';
+        sheet.style.padding = '5mm 15mm 5mm 15mm';
 
         // Absoutely position the page number to ensure it doesn't push flow or get caught in overflow
         if (pageNumEl) {
           // @ts-ignore
           pageNumEl.style.position = 'absolute';
           // @ts-ignore
-          pageNumEl.style.bottom = '10mm'; // Higher up as requested
+          pageNumEl.style.bottom = '15mm'; // Adjusted for visibility
           // @ts-ignore
           pageNumEl.style.right = '15mm';
           // @ts-ignore
@@ -141,6 +152,10 @@ export async function initInvoiceDetailPage() {
           sheet.style.position = originalInfo[i].position;
           // @ts-ignore
           sheet.style.pageBreakAfter = originalInfo[i].pageBreakAfter;
+          // @ts-ignore
+          sheet.style.overflow = originalInfo[i].overflow;
+          // @ts-ignore
+          sheet.style.maxHeight = originalInfo[i].maxHeight;
 
           if (originalInfo[i].pageNumEl) {
             // @ts-ignore
@@ -179,6 +194,10 @@ export async function initInvoiceDetailPage() {
           sheet.style.position = originalInfo[i].position;
           // @ts-ignore
           sheet.style.pageBreakAfter = originalInfo[i].pageBreakAfter;
+          // @ts-ignore
+          sheet.style.overflow = originalInfo[i].overflow;
+          // @ts-ignore
+          sheet.style.maxHeight = originalInfo[i].maxHeight;
 
           if (originalInfo[i].pageNumEl) {
             // @ts-ignore


### PR DESCRIPTION
Closes #169

## 概要 (Overview)
「中身が何もないのに白紙ページが生成される」という頑固な問題に対して、目に見えない要素のはみ出しを物理的に遮断する最終手段を適用しました。

## 修正内容 (Changes)
1.  **`overflow: hidden` の強制適用**
    - PDF生成時のみ、ページコンテナ（`.invoice-sheet`）に `overflow: hidden` を適用しました。
    - これにより、目に見えない `box-shadow` や `::after` 擬似要素、あるいは微妙なレンダリング誤差ではみ出した「白い何か」が強制的にクリッピングされ、次のページに漏れ出すのを防ぎます。
2.  **`max-height` の安全設定**
    - コンテンツの最大高さを `275mm` に制限しました。A4（297mm）に対して約2cm以上の余裕を持たせることで、どんなに計算がズレても物理的に1ページに収まるようにしました。
3.  **パディングの再調整**
    - 下部パディングを `20mm` から `5mm` に減らし、コンテンツが `max-height` 制限に引っかからないように余裕を持たせました（ページ番号は絶対配置なのでフローには影響しません）。

## 期待される動作 (Expected Behavior)
- 目に見えないゴミ要素による改ページがなくなります。
- どんなにギリギリのレイアウトでも、`275mm` でカットされるため、次ページへのオーバーフローが発生しません。

## チェックリスト (Checklist)
- [x] `overflow: hidden` によるクリッピング実装
- [x] `max-height` による物理的サイズ制限
- [x] ワークフロー遵守
