### PR TITLE
fix(invoice): increase bottom padding and lower footer to prevent overlap

### DIFF
--- a/02_dashboard/src/invoiceDetail.js
+++ b/02_dashboard/src/invoiceDetail.js
@@ -87,17 +87,18 @@ export async function initInvoiceDetailPage() {
         // @ts-ignore
         sheet.style.position = 'relative';
 
-        // Set padding: Top 10mm, Sides 10mm, Bottom 0mm
-        // Footer is handled by absolute positioning, so we just need side margins for content.
+        // Set padding: Top 10mm, Sides 15mm, Bottom 25mm
+        // Increased bottom padding to 25mm to create a "No Fly Zone" for the table content,
+        // ensuring it absolutely cannot overlap with the footer.
         // @ts-ignore
-        sheet.style.padding = '10mm 15mm 10mm 15mm';
+        sheet.style.padding = '10mm 15mm 25mm 15mm';
 
         // Absoutely position the page number
         if (pageNumEl) {
           // @ts-ignore
           pageNumEl.style.position = 'absolute';
           // @ts-ignore
-          pageNumEl.style.bottom = '12mm'; // Nice position at bottom
+          pageNumEl.style.bottom = '5mm'; // Lowered significantly (was 12mm) to sit at the page edge
           // @ts-ignore
           pageNumEl.style.right = '15mm';
           // @ts-ignore


### PR DESCRIPTION
Closes #173

## 概要 (Overview)
ページ番号（フッター）が表のコンテンツに被ってしまう問題を解消するため、コンテンツエリアの安全地帯（パディング）を拡大し、ページ番号の表示位置を下げました。

## 修正内容 (Changes)
1.  **下部パディングの拡大（25mm）**
    - コンテンツ（`.invoice-sheet`）の下部パディングを `10mm` から **`25mm`** に大幅に拡大しました。
    - これにより、表などのコンテンツがページ下部 25mm のラインで強制的に止まり、それ以上下には描画されなくなります。これが「被り」を防ぐ物理的な壁となります。
2.  **ページ番号位置の引き下げ（5mm）**
    - ページ番号の固定位置を `bottom: 12mm` から **`5mm`** に変更しました。
    - コンテンツは `25mm` で止まり、ページ番号は `5mm` にあるため、その間には `20mm` もの安全地帯が生まれ、絶対に被ることがなくなります。

## 期待される動作 (Expected Behavior)
- ページ番号は用紙のかなり下の方（下端から5mm）に表示されます。
- 表などのコンテンツは、ページ番号よりもずっと上（下端から25mm）で止まります。
- 結果として、文字被りは完全に解消されます。

## チェックリスト (Checklist)
- [x] パディングによる安全地帯の確保
- [x] フッター位置の引き下げ
- [x] ワークフロー遵守
