### PR TITLE
feat(survey): fix unclickable QR code button in survey creation

### DIFF
--- a/02_dashboard/src/surveyCreation.js
+++ b/02_dashboard/src/surveyCreation.js
@@ -1796,6 +1796,14 @@ function setupEventListeners() {
         });
     }
     // --- end of bizcard setting event listener ---
+
+    // --- QR Code Modal ---
+    const openQrModalBtn = document.getElementById('openQrModalBtn');
+    if (openQrModalBtn) {
+        openQrModalBtn.addEventListener('click', () => {
+            handleOpenModal('qrCodeModal', resolveDashboardAssetPath('modals/qrCodeModal.html'));
+        });
+    }
 }
 
 // --- Data Manipulation Handlers ---


### PR DESCRIPTION
### Definition of Done
- [x] Clicking the "QR Code" button opens the QR Code modal.
- [x] No regression in other button functionalities.
- [x] Linting passes.

### Summary
The QR Code button (`openQrModalBtn`) in the survey creation screen was previously inactive. I have added an event listener in `02_dashboard/src/surveyCreation.js` that triggers `handleOpenModal` with the correct path to the `qrCodeModal.html` when the button is clicked.

This confirms functionality restoration as per the user's request.
