### PR TITLE
fix: SPEEDレビュー — 初回サイドバー自動折りたたみ(0.7s)復帰とテーブル/チャート連動改善

### DIFF
--- a/02_dashboard/speed-review.html
+++ b/02_dashboard/speed-review.html
@@ -108,6 +108,31 @@
             box-shadow: inset 0 1px 0 #e5e7eb;
         }
 
+        .graph-data-table__row.is-highlighted {
+            background-color: rgba(26, 115, 232, 0.08);
+        }
+
+        .graph-data-table__row.is-highlighted td {
+            color: #1a73e8;
+            font-weight: 600;
+        }
+
+        .table-scroll-shadow {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 28px;
+            background: linear-gradient(to left, rgba(15, 23, 42, 0.18), rgba(15, 23, 42, 0));
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            pointer-events: none;
+        }
+
+        .table-scroll-shadow.is-visible {
+            opacity: 1;
+        }
+
         @media (max-width: 767px) {
             .graph-data-table-container {
                 height: auto;
@@ -154,7 +179,7 @@
                             </div>
                         </div>
                         <div id="kpi-current-question-card"
-                            class="bg-surface border border-outline-variant rounded-2xl shadow-sm md:col-span-2 flex flex-col justify-center transition-all cursor-pointer hover:ring-2 ring-primary/20 group">
+                            class="bg-surface border border-outline-variant rounded-2xl shadow-sm md:col-span-2 flex flex-col justify-center transition-all cursor-pointer hover:ring-2 hover:bg-primary/5 ring-primary/20 group">
                             <div class="flex items-stretch h-full">
                                 <!-- 左側：設問選択エリア（クリック領域のメイン） -->
                                 <div class="flex-1 p-5 min-w-0 flex flex-col justify-center">
@@ -173,6 +198,11 @@
                                             <span class="material-icons text-on-surface-variant group-hover:text-primary transition-colors shrink-0">expand_more</span>
                                         </div>
                                     </div>
+                                    <button id="question-change-link" type="button"
+                                        class="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-primary hover:text-primary/80">
+                                        <span class="material-icons text-sm">edit</span>
+                                        設問を変更
+                                    </button>
                                 </div>
                                 <!-- 右側：ナビゲーションエリア（セパレーター付き） -->
                                 <div class="shrink-0 flex items-center px-6 border-l border-outline-variant/50 bg-surface-variant/5 rounded-r-2xl">
@@ -232,7 +262,9 @@
 
                 <div class="relative">
                     <div id="main-content-wrapper" class="w-full transition-all duration-300 lg:mr-80">
-                        <div class="rounded-xl border border-outline-variant bg-surface relative min-h-[300px] overflow-x-auto">
+                        <div id="review-table-scroll-container"
+                            class="rounded-xl border border-outline-variant bg-surface relative min-h-[300px] overflow-x-auto">
+                            <div id="review-table-scroll-shadow" class="table-scroll-shadow sm:hidden" aria-hidden="true"></div>
                             <table class="w-full divide-y divide-outline-variant review-table table-fixed min-w-[960px]"
                                 id="reviewTable">
                                 <thead class="bg-surface-variant">


### PR DESCRIPTION
### Motivation
- 初回ロード時にサイドバーを短時間で自動折りたたむ既存仕様（0.7秒）を復帰させて画面占有を抑えるため。 
- マトリクスチャートと集計テーブルの連動性を高め、ホバーや凡例操作で対応行を視覚的に強調できるようにするため。 
- テーブルの横スクロール余地をユーザーに示すスクロールシャドウを追加して操作性を改善するため。 

### Description
- `02_dashboard/src/speed-review.js`に初回ロード時のみ0.7秒後にサイドバーを自動で閉じるロジックを追加し、状態は`localStorage`の`speedReviewSidebarCollapsed`で保持するようにしました。 
- マトリクス集計テーブルの行に`data-matrix-row`/`data-matrix-column`属性を付与し、`highlightMatrixTableRow`/`clearMatrixTableHighlight`と`normalizeDataKey`を実装してチャートのホバーで該当行をハイライトできるようにしました。 
- 凡例クリックでフォーカスを固定する`applyLegendFocus`を追加し、`updateLegendFade`を凡例フォーカス対応に改修しました。 
- レビュー表の右端にスクロール可能なことを示すシャドウ要素と`setupTableScrollIndicator`を追加し、スクロール状態に応じて表示を切替えるようにしました。 
- UI側では`02_dashboard/speed-review.html`にハイライト用のCSSとレビュー表用のスクロールシャドウ要素、設問変更ボタンや空状態用アクションボタンを追加しました。 

### Testing
- 自動化テストは実行していません（無し）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987fce2d6308323aca79174c45dfcbf)