### PR TITLE
premium_registration_spa.html: アカウント情報確認モーダルの表示不具合を修正

### DIFF
--- a/02_dashboard/premium_registration_spa.html
+++ b/02_dashboard/premium_registration_spa.html
@@ -515,9 +515,15 @@
 
                     // Show Modal
                     if (modal) {
+                        console.log('Removing hidden class from modal');
                         modal.classList.remove('hidden');
+
+                        // Force reflow to ensure transition works
+                        void modal.offsetWidth;
+
                         // Small delay for transition
                         setTimeout(() => {
+                            console.log('Animating modal opacity');
                             modal.classList.remove('opacity-0');
                             modalContent.classList.remove('scale-95');
                         }, 50);
@@ -612,7 +618,7 @@
 
             // Run check on load
             console.log('Running checkAccountInfo from DOMContentLoaded');
-            checkAccountInfo();
+            setTimeout(checkAccountInfo, 100);
 
         });
     </script>

--- a/docs/templates/issue_body.md
+++ b/docs/templates/issue_body.md
@@ -1,45 +1,10 @@
-### Implementation Proposal
+### 不具合の内容
+`premium_signup_new.html`の「今すぐ申し込む」ボタン等から`premium_registration_spa.html`に遷移した際、ユーザー情報（`dummyUserData`等）が存在する場合でも、登録情報の確認モーダルが表示されず、直接入力画面が表示されてしまう。
 
-To resolve this Issue, I will proceed with the implementation according to the following plan.
+### 期待する動作
+ユーザー情報が存在する場合、画面ロード時に「登録情報の確認モーダル」が表示され、既存情報を使用するかどうかを選択できること。
 
-#### 1. **Pre-investigation Summary**
-- グラフ分析画面のExcelエクスポート機能において、ユーザーから出力内容の選択（目次、画像、マトリックス全項目、対象外リスト）を行いたいという要望があった。
-- 現状のエクスポート機能は、画面の表示状態に依存しており、マトリックス設問の全行出力などが困難であった。
-
-**Files to be changed:**
-- `02_dashboard/graph-page.html`
-- `02_dashboard/src/graph-page.js`
-- `02_dashboard/modals/exportOptionsModal.html` (New file)
-- `02_dashboard/src/services/speedReviewService.js`
-- `02_dashboard/src/speed-review.js`
-- `02_dashboard/src/ui/speedReviewRenderer.js`
-- `WEEKLY_CHANGELOG.md`
-
-#### 2. **Contribution to Project Goals**
-- ユーザーが印刷用や報告用に適した、より詳細でカスタマイズ可能なExcelレポートを作成できるようにすることで、ツールの利便性を大幅に向上させる。
-
-#### 3. **Overview of Changes**
-- エクスポート設定モーダルの導入。
-- 目次シートの自動生成機能。
-- マトリックス設問の全行一括出力機能の実装。
-- パフォーマンスとメモリ管理の最適化。
-
-#### 4. **Specific Work Content for Each File**
-- `02_dashboard/graph-page.html`: モーダルコンテナの追加とスタイル調整。
-- `02_dashboard/src/graph-page.js`: モーダル表示ロジックとExcelエクスポートロジックの強化（目次生成、マトリックス全出力対応）。
-- `02_dashboard/modals/exportOptionsModal.html`: 出力オプション選択UIの実装。
-- `02_dashboard/src/services/speedReviewService.js`: 名前分割ロジック（姓・名）の改善。
-- `02_dashboard/src/speed-review.js`: 画像パス解決ロジックの強化と表示状態管理の改善。
-- `02_dashboard/src/ui/speedReviewRenderer.js`: マトリックス設問の表示ロジックと回答フォーマットの改善。
-- `WEEKLY_CHANGELOG.md`: 変更内容の記録。
-
-#### 5. **Definition of Done**
-- [x] 全ての必要なコード変更が実装された。
-- [x] エクスポートオプションモーダルが正しく表示され、選択内容がエクスポートに反映される。
-- [x] 目次シートが生成され、各シートへのリンクが機能する。
-- [x] マトリックス設問の全行が正しくExcelに出力される。
-- [x] ドキュメント（WEEKLY_CHANGELOG.md）が更新された。
-- [x] 実装が手動で検証された。
-
----
-If you approve, please reply to this comment with "Approve".
+### 調査方針
+1. `premium_registration_spa.html`内の`checkAccountInfo`関数の実行タイミングとロジックを確認する。
+2. JSエラーが発生していないか確認し、堅牢な実装に修正する。
+3. モーダル表示に関わるDOM要素の取得やクラス操作（`hidden`削除など）が正しく行われているか検証する。

--- a/docs/templates/pr_body.md
+++ b/docs/templates/pr_body.md
@@ -1,22 +1,12 @@
-### Summary
-- サンプル回答用画像を、同一画像の複製から動的に生成されたリアリスティックな画像に更新しました。
-- 命名規則を「アンケートID_連番_判別コード」の形式に変更し、システム連携のテストを容易にしました。
-- 画像生成用のPythonスクリプト `tools/generate_realistic_images.py` を追加しました。
+## 概要
+`premium_signup_new.html` から遷移した際、`premium_registration_spa.html` のユーザー情報確認モーダルが表示されない不具合を修正しました。
 
-### Related Issue
-Closes #239
+## 変更点
+- `premium_registration_spa.html` の修正:
+  - `checkAccountInfo` 関数内にデバッグログを追加。
+  - CSSトランジションが確実に発火するように、`opacity-0` クラスを削除する前に `void modal.offsetWidth` を呼び出して再描画（リフロー）を強制しました。
+  - `DOMContentLoaded` 内での `checkAccountInfo` 実行タイミングを100ms遅延させ、画面描画が安定してから処理が走るようにしました。
 
-### Changes
-- **New Script:** `tools/generate_realistic_images.py`
-    - Pillowを使用して、会社名、氏名、ロゴ（名刺）、手書き風の線とテキスト（手書きメモ）、図面風の描画（添付資料）をランダムに生成します。
-- **Updated Images:** `media/generated/sv_0003_26009/` 配下の全3,600枚を再生成。
-    - 名刺表: `*_1.jpg`
-    - 名刺裏: `*_2.jpg`
-    - 手書き: `*_handwriting.png`
-    - 添付: `*_attachment.jpg`
-
-### Verification Results
-- [x] スクリプトの正常動作確認。
-- [x] 生成された画像の目視確認（日本語の描画、ランダム性）。
-- [x] 命名規則が指定通りであることを確認。
-
+## テスト
+- ユーザーデータが存在する場合に、ページロード時にモーダルが正しくフェードイン表示されることを確認しました。
+- コンソールログで実行フローを確認しました。


### PR DESCRIPTION
## 概要
`premium_signup_new.html` から遷移した際、`premium_registration_spa.html` のユーザー情報確認モーダルが表示されない不具合を修正しました。

## 変更点
- `premium_registration_spa.html` の修正:
  - `checkAccountInfo` 関数内にデバッグログを追加。
  - CSSトランジションが確実に発火するように、`opacity-0` クラスを削除する前に `void modal.offsetWidth` を呼び出して再描画（リフロー）を強制しました。
  - `DOMContentLoaded` 内での `checkAccountInfo` 実行タイミングを100ms遅延させ、画面描画が安定してから処理が走るようにしました。

## テスト
- ユーザーデータが存在する場合に、ページロード時にモーダルが正しくフェードイン表示されることを確認しました。
- コンソールログで実行フローを確認しました。
