### PR TITLE
fix: address public login review findings

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -4118,6 +4118,108 @@ body.lock {
     box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18) !important;
 }
 
+#before-login .public-news-section {
+    padding: 0 5%;
+    background: linear-gradient(180deg, #eef4ff 0%, #f8fafc 100%);
+}
+
+#before-login .public-news-section[hidden] {
+    display: none !important;
+}
+
+#before-login .public-news-bar {
+    width: min(1120px, 100%);
+    margin: -28px auto 0;
+    padding: 18px 20px;
+    position: relative;
+    z-index: 3;
+    display: grid;
+    grid-template-columns: minmax(150px, 0.18fr) minmax(0, 1fr) auto;
+    gap: 18px;
+    align-items: center;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(12px);
+}
+
+#before-login .public-news-bar__heading {
+    border-right: 1px solid rgba(148, 163, 184, 0.32);
+}
+
+#before-login .public-news-bar__eyebrow {
+    margin: 0 0 4px;
+    color: #2138bc;
+    font-size: 11px;
+    font-weight: 900;
+    letter-spacing: 0.18em;
+}
+
+#before-login .public-news-bar h2 {
+    margin: 0;
+    color: #0f172a;
+    font-size: clamp(18px, 2vw, 24px);
+    font-weight: 900;
+    letter-spacing: 0.04em;
+}
+
+#before-login .public-news-list {
+    display: grid;
+    gap: 8px;
+}
+
+#before-login .public-news-item {
+    display: grid;
+    grid-template-columns: 88px minmax(0, 1fr);
+    gap: 14px;
+    align-items: start;
+    color: #0f172a;
+    text-decoration: none;
+}
+
+#before-login .public-news-item time {
+    color: #64748b;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1.5;
+}
+
+#before-login .public-news-item__body {
+    min-width: 0;
+}
+
+#before-login .public-news-item strong {
+    display: block;
+    color: #0f172a;
+    font-size: 14px;
+    font-weight: 900;
+    line-height: 1.45;
+}
+
+#before-login .public-news-item p {
+    margin: 2px 0 0;
+    color: #64748b;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.5;
+}
+
+#before-login .public-news-bar__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 40px;
+    padding: 0 16px;
+    border: 1px solid rgba(33, 56, 188, 0.26);
+    border-radius: 999px;
+    color: #2138bc;
+    font-size: 13px;
+    font-weight: 900;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
 #before-login #input-box .scenario-accounts {
     margin: 10px 0 12px;
     padding: 10px 12px;
@@ -4223,6 +4325,22 @@ body.lock {
 }
 
 @media (max-width: 900px) {
+    #before-login .public-news-bar {
+        grid-template-columns: 1fr;
+        gap: 14px;
+        margin-top: -16px;
+    }
+
+    #before-login .public-news-bar__heading {
+        padding-bottom: 12px;
+        border-right: 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.32);
+    }
+
+    #before-login .public-news-bar__link {
+        width: 100%;
+    }
+
     #before-login #section7 article .no-flex ul.list3 {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -4249,6 +4367,20 @@ body.lock {
     #before-login .hero-primary-cta,
     #before-login .hero-secondary-cta {
         width: 100%;
+    }
+
+    #before-login .public-news-section {
+        padding: 0 4%;
+    }
+
+    #before-login .public-news-bar {
+        padding: 16px;
+        border-radius: 18px;
+    }
+
+    #before-login .public-news-item {
+        grid-template-columns: 1fr;
+        gap: 2px;
     }
 
     #before-login #section7 article .no-flex ul.list3 {

--- a/css/page.css
+++ b/css/page.css
@@ -197,6 +197,15 @@ a:hover {
     text-decoration: none;
 }
 
+#before-login a:focus-visible,
+#before-login button:focus-visible,
+#before-login input:focus-visible,
+#before-login summary:focus-visible {
+    outline: 3px solid #38bdf8;
+    outline-offset: 4px;
+    box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.24);
+}
+
 a img,
 img {
     border: 0;
@@ -4069,6 +4078,194 @@ body.lock {
 @media screen and (max-width: 736px) {
     label {
         font-weight: normal;
+    }
+}
+
+/* Login-front review fixes: keep the existing page structure while reducing visual noise. */
+#before-login .hero-cta-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-top: 24px;
+}
+
+#before-login .hero-primary-cta,
+#before-login .hero-secondary-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0 24px;
+    border-radius: 999px;
+    font-weight: 800;
+    text-decoration: none;
+}
+
+#before-login .hero-primary-cta {
+    background: linear-gradient(90deg, #c412a2, #2138bc);
+    color: #fff;
+    box-shadow: 0 16px 34px rgba(33, 56, 188, 0.28);
+}
+
+#before-login .hero-secondary-cta {
+    border: 1px solid rgba(255, 255, 255, 0.52);
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+}
+
+#before-login #input-box.form-container {
+    max-width: 400px !important;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18) !important;
+}
+
+#before-login #input-box .scenario-accounts {
+    margin: 10px 0 12px;
+    padding: 10px 12px;
+    border: 1px dashed #cbd5e1;
+    border-radius: 12px;
+    background: #f8fafc;
+}
+
+#before-login #input-box .scenario-accounts__title {
+    margin: 0;
+    color: #64748b;
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+}
+
+#before-login #input-box .scenario-accounts[open] .scenario-accounts__title {
+    margin-bottom: 10px;
+}
+
+#before-login .signup-inline-link {
+    margin: 12px 0 0;
+    color: #64748b;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: center;
+}
+
+#before-login .signup-inline-link a {
+    color: #2138bc;
+    font-weight: 800;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+#before-login #section7 article.tate {
+    min-height: auto;
+    height: auto;
+    overflow: visible;
+}
+
+#before-login #section7 article .no-flex.white {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 7vh 5% 5vh;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+}
+
+#before-login #section7 article .no-flex ul.list3 {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+    margin-top: 28px;
+}
+
+#before-login #section7 article .no-flex ul.list3 li {
+    width: auto;
+}
+
+#before-login #section7 article .no-flex ul.list3 li a {
+    min-height: 72px;
+    height: auto;
+    padding: 14px 18px;
+    border-width: 1px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.72);
+    box-shadow: none;
+    font-size: 14px;
+    line-height: 1.45;
+}
+
+#before-login #section7 article .no-flex ul.list3 li a .arrow-round {
+    right: 16px;
+    left: auto;
+    bottom: 18px;
+    transform: scale(0.78);
+    transform-origin: right center;
+}
+
+#before-login article.tate footer#before-footer {
+    height: auto;
+    min-height: 0;
+    padding: 42px 5% !important;
+    background: #f8fafc;
+}
+
+#before-login article.tate footer#before-footer ul {
+    width: min(680px, 58%);
+}
+
+#before-login article.tate footer#before-footer .footer-primary-cta {
+    display: inline-flex;
+    width: auto;
+    min-height: 40px;
+    align-items: center;
+    padding: 0 18px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #c412a2, #2138bc);
+    color: #fff;
+}
+
+@media (max-width: 900px) {
+    #before-login #section7 article .no-flex ul.list3 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    #before-login article.tate footer#before-footer {
+        display: block;
+    }
+
+    #before-login article.tate footer#before-footer h2,
+    #before-login article.tate footer#before-footer ul {
+        width: 100%;
+    }
+
+    #before-login article.tate footer#before-footer ul {
+        margin-top: 24px;
+    }
+}
+
+@media (max-width: 600px) {
+    #before-login .hero-cta-group {
+        flex-direction: column;
+    }
+
+    #before-login .hero-primary-cta,
+    #before-login .hero-secondary-cta {
+        width: 100%;
+    }
+
+    #before-login #section7 article .no-flex ul.list3 {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    #before-login #section7 article .no-flex ul.list3 li a {
+        min-height: 56px;
+    }
+
+    #before-login article.tate footer#before-footer ul {
+        display: block;
+    }
+
+    #before-login article.tate footer#before-footer ul li {
+        width: 100%;
     }
 }
 

--- a/data/README.md
+++ b/data/README.md
@@ -6,5 +6,6 @@
 - `demo/demo_surveys/` - sample survey payloads for charts and demo screens.
 - `demo/demo_answers/` - answer datasets paired with demo surveys.
 - `demo/demo_business-cards/` - persona business-card data linked to demo answers.
+- `news.json` - mock public-news feed for the login-front page; production source is expected to move to `support.speed-ad.com/news.json`.
 
 Large archival dumps live in `アーカイブ/data-dumps/` to keep runtime assets light.

--- a/data/news.json
+++ b/data/news.json
@@ -1,0 +1,26 @@
+{
+  "updatedAt": "2026-04-28",
+  "items": [
+    {
+      "date": "2026-04-28",
+      "displayDate": "2026.04.28",
+      "title": "ログイン前ページのお知らせ欄を準備中です",
+      "summary": "本番では support.speed-ad.com 側の静的JSONを正本にし、ログイン前ページには最大3件を表示する想定です。",
+      "url": "https://support.speed-ad.com/news/login-front-news/"
+    },
+    {
+      "date": "2026-04-27",
+      "displayDate": "2026.04.27",
+      "title": "公開トップの導線整理を進めています",
+      "summary": "無料ではじめる、お客様のお声、サポート導線の役割を分け、初回訪問時に迷いにくい構成へ整えています。",
+      "url": "https://support.speed-ad.com/news/public-top-navigation/"
+    },
+    {
+      "date": "2026-04-24",
+      "displayDate": "2026.04.24",
+      "title": "モック画面と開発環境の差分整理を継続しています",
+      "summary": "本番アプリ、公開LP、静的サブドメインに分けて、回収対象と参考保持対象を確認しています。",
+      "url": "https://support.speed-ad.com/news/mock-screen-recovery/"
+    }
+  ]
+}

--- a/docs/画面設計/仕様/21_support_site_separation_spec.md
+++ b/docs/画面設計/仕様/21_support_site_separation_spec.md
@@ -2,7 +2,7 @@
 owner: product
 status: draft
 document_type: 方針メモ（ADRではなくPRD前段の備忘仕様）
-last_reviewed: 2026-04-23
+last_reviewed: 2026-04-28
 review_cycle: quarterly
 ---
 
@@ -95,6 +95,8 @@ review_cycle: quarterly
 | 特定商取引法表示 | `02_dashboard/specified-commercial-transactions.html` | `https://support.speed-ad.com/tokushoho/` |
 | 個人情報保護方針 | `02_dashboard/personal-data-protection-policy.html` | `https://support.speed-ad.com/privacy/` |
 | 更新履歴 | `02_dashboard/changelog.html`（実在する場合） | `https://support.speed-ad.com/changelog/` |
+| お知らせ一覧/詳細 | 新規（ログイン前トップのティザーから接続） | `https://support.speed-ad.com/news/`, `https://support.speed-ad.com/news/<slug>/` |
+| お知らせJSON | 新規（ログイン前トップの最大3件表示で参照） | `https://support.speed-ad.com/news.json` |
 | ログイン前画面 | `index.html`（ルート） | **据え置き**（変更なし） |
 
 ---
@@ -417,6 +419,7 @@ SPPED-AD-TEST/
 | 11 | URL正規化ルール（www有無／末尾スラッシュ／クエリ保持） | M1 | 開発リード |
 | 12 | HSTS preload 採用可否 | M3前 | 開発リード＋セキュリティ |
 | 13 | 個人情報インシデント対応プレイブック | M3前 | 個人情報保護責任者＋セキュリティ |
+| 14 | `/news/` と `news.json` の運用方式（CORS取得／ビルド同梱、キャッシュ、公開フロー） | M1 | PO＋開発リード |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -1238,6 +1238,16 @@
     </div>
   </div>
     </div>
+    <div class="public-news-section" id="public-news-section" data-news-endpoint="data/news.json" data-news-detail-url="https://support.speed-ad.com/news/" hidden>
+      <article class="public-news-bar" aria-labelledby="public-news-title">
+        <div class="public-news-bar__heading">
+          <p class="public-news-bar__eyebrow">NEWS</p>
+          <h2 id="public-news-title">お知らせ</h2>
+        </div>
+        <div class="public-news-list" id="public-news-list" aria-live="polite"></div>
+        <a class="public-news-bar__link" href="https://support.speed-ad.com/news/" target="_blank" rel="noopener noreferrer">一覧を見る</a>
+      </article>
+    </div>
 <div class="section" id="section1">
       <article>
         <div class="flex row">
@@ -1510,6 +1520,8 @@
       const googleButtonModal = modalContent.querySelector('.button--google');
       const customerVoiceTeaserGrid = document.getElementById('customer-voice-teaser-grid');
       const customerVoiceTeaserStatus = document.getElementById('customer-voice-teaser-status');
+      const publicNewsSection = document.getElementById('public-news-section');
+      const publicNewsList = document.getElementById('public-news-list');
       const pageMain = document.querySelector('main');
       const modalFocusableSelector = [
         'a[href]',
@@ -1541,6 +1553,9 @@
         if (!relativePath) {
           return relativePath;
         }
+        if (/^(https?:)?\/\//.test(relativePath)) {
+          return relativePath;
+        }
         const { pathname } = window.location;
         let basePath = pathname;
         if (!basePath.endsWith('/')) {
@@ -1559,6 +1574,49 @@
           .replace(/>/g, '&gt;')
           .replace(/"/g, '&quot;')
           .replace(/'/g, '&#39;');
+      }
+      async function loadPublicNews() {
+        if (!publicNewsSection || !publicNewsList) {
+          return;
+        }
+        const newsEndpoint = publicNewsSection.dataset.newsEndpoint || 'data/news.json';
+        const fallbackNewsUrl = publicNewsSection.dataset.newsDetailUrl || 'https://support.speed-ad.com/news/';
+        try {
+          const response = await fetch(resolveAppPath(newsEndpoint));
+          if (!response.ok) {
+            throw new Error(`Failed to load public news: ${response.status}`);
+          }
+          const payload = await response.json();
+          const items = Array.isArray(payload?.items)
+            ? payload.items.filter((item) => item?.title).slice(0, 3)
+            : [];
+          if (!items.length) {
+            publicNewsSection.hidden = true;
+            return;
+          }
+          publicNewsList.innerHTML = items.map((item) => {
+            const displayDate = item.displayDate || item.date || item.publishedAt || '';
+            const dateTime = item.date || item.publishedAt || '';
+            const summary = item.summary ? `<p>${escapeHtml(item.summary)}</p>` : '';
+            const url = item.url || fallbackNewsUrl;
+            const timeMarkup = displayDate
+              ? `<time datetime="${escapeHtml(dateTime || displayDate)}">${escapeHtml(displayDate)}</time>`
+              : '';
+            return `
+              <a class="public-news-item" href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">
+                ${timeMarkup}
+                <span class="public-news-item__body">
+                  <strong>${escapeHtml(item.title)}</strong>
+                  ${summary}
+                </span>
+              </a>
+            `;
+          }).join('');
+          publicNewsSection.hidden = false;
+        } catch (error) {
+          console.warn('お知らせの読み込みに失敗しました:', error);
+          publicNewsSection.hidden = true;
+        }
       }
       async function loadCustomerVoiceTeasers() {
         if (!customerVoiceTeaserGrid || !customerVoiceTeaserStatus) {
@@ -1979,6 +2037,7 @@
             }
         }
       });
+      loadPublicNews();
       loadCustomerVoiceTeasers();
       maybeOpenSignupFromIntent();
     });

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <title>SPEED-AD - ログイン</title>
   <link rel="icon" href="img/logo2.svg" type="image/svg+xml">
   <link rel="stylesheet" href="css/page.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.9.7/jquery.fullpage.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -1154,7 +1153,8 @@
   <main>
   <div id="fullpage">
     <div class="section " id="section0">
-      <div id="all" role="main">
+      <div id="top" aria-hidden="true"></div>
+      <div id="all">
     <div id="text-box">
       <ul>
         <li>WEBアンケート作成</li>
@@ -1164,7 +1164,10 @@
       <h1><img src="img/logo.svg" alt="SPEED-AD"><span>～スピード アド～</span></h1>
       <p>SPEED ADは、展示会やセミナーなどのイベント向けソリューションです。<br>
         無料のWEBアンケート作成、名刺のデータ化、御礼メールの送信を一気通貫で提供し、獲得したリードの有効活用をワンストップで実現します</p>
-      <a class="hero-secondary-cta" href="customer-voices/index.html">お客様のお声を見る</a>
+      <div class="hero-cta-group">
+        <a class="hero-primary-cta" href="?intent=signup#top">無料ではじめる</a>
+        <a class="hero-secondary-cta" href="customer-voices/index.html">お客様のお声を見る</a>
+      </div>
     </div>
     <div id="input-box" class="form-container">
       <h1 class="form-container__title">SPEED AD ログイン</h1>
@@ -1184,7 +1187,7 @@
           <label style="display: flex; align-items: flex-start; gap: 8px; cursor: pointer; font-size: 0.85rem; color: #333; line-height: 1.5;">
             <input type="checkbox" id="login-terms-agree" name="login-terms-agree" class="form-options__checkbox-input" required aria-required="true" style="margin-top: 3px; flex-shrink: 0;">
             <span>
-              <a href="http://127.0.0.1:5500/02_dashboard/terms-of-service.html" target="_blank" rel="noopener noreferrer" class="form-options__link">利用規約</a>と<a href="https://www.abroad-o.com/rule.html" target="_blank" rel="noopener noreferrer" class="form-options__link">プライバシーポリシー</a>および<a href="02_dashboard/personal-data-protection-policy.html" target="_blank" rel="noopener noreferrer" class="form-options__link">個人情報保護方針</a>に同意する
+              <a href="02_dashboard/terms-of-service.html" target="_blank" rel="noopener noreferrer" class="form-options__link">利用規約</a>と<a href="https://www.abroad-o.com/rule.html" target="_blank" rel="noopener noreferrer" class="form-options__link">プライバシーポリシー</a>および<a href="02_dashboard/personal-data-protection-policy.html" target="_blank" rel="noopener noreferrer" class="form-options__link">個人情報保護方針</a>に同意する
             </span>
           </label>
           <div id="login-terms-agree-error" class="form-group__error-message" role="alert"></div>
@@ -1196,8 +1199,8 @@
           </label>
           <a href="02_dashboard/forgot-password.html" class="form-options__link" style="font-size: 0.85rem; white-space: nowrap;">パスワードを忘れた方</a>
         </div>
-        <div class="scenario-accounts">
-          <p class="scenario-accounts__title">シナリオテスト用アカウント（クリックで自動入力）</p>
+        <details class="scenario-accounts">
+          <summary class="scenario-accounts__title">シナリオテスト用アカウント</summary>
           <ul class="scenario-accounts__list">
             <li>
               <a href="#" class="scenario-accounts__link" data-email="user">
@@ -1218,7 +1221,7 @@
               </a>
             </li>
           </ul>
-        </div>
+        </details>
         <button class="button button--filled" type="submit">
           <span class="button__spinner"></span>
           ログイン
@@ -1231,7 +1234,7 @@
         <img class="button--google__logo" src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google logo">
         Googleでログイン
       </button>
-      <button class="button button--tonal" type="button">新規アカウント作成</button>
+      <p class="signup-inline-link">新規利用の方は <a href="?intent=signup#top" data-signup-trigger>無料アカウント作成</a></p>
     </div>
   </div>
     </div>
@@ -1402,10 +1405,10 @@
     <ul>
       <li>
         <h3>SPEED-ADについて</h3>
-        <p><a href="index.html">無料ではじめる</a></p>
-        <p><a href="index.html#top">ログイン</a></p>
+        <p><a class="footer-primary-cta" href="?intent=signup#top">無料ではじめる</a></p>
+        <p><a href="#top">ログイン</a></p>
         <p><a href="customer-voices/index.html">お客様のお声</a></p>
-        <p><a href="index.html">お問い合わせ</a></p>
+        <p><a href="02_dashboard/bug-report.html">お問い合わせ</a></p>
         <p><a href="https://support.speed-ad.com/help/" target="_blank" rel="noopener noreferrer">ヘルプ</a></p>
       </li>
       <li>
@@ -1453,7 +1456,7 @@
             <label class="form-options__checkbox-label" style="justify-content: flex-start; margin-bottom: 0;">
                 <input type="checkbox" id="terms-agree" name="terms-agree" class="form-options__checkbox-input" required aria-required="true">
                 <span style="font-weight: normal; font-size: 0.9rem;">
-                    <a href="http://127.0.0.1:5500/02_dashboard/terms-of-service.html" target="_blank" rel="noopener noreferrer" class="form-options__link">利用規約</a>と<a href="https://www.abroad-o.com/rule.html" target="_blank" rel="noopener noreferrer" class="form-options__link">プライバシーポリシー</a>および<a href="02_dashboard/personal-data-protection-policy.html" target="_blank" rel="noopener noreferrer" class="form-options__link">個人情報保護方針</a>に同意する
+                    <a href="02_dashboard/terms-of-service.html" target="_blank" rel="noopener noreferrer" class="form-options__link">利用規約</a>と<a href="https://www.abroad-o.com/rule.html" target="_blank" rel="noopener noreferrer" class="form-options__link">プライバシーポリシー</a>および<a href="02_dashboard/personal-data-protection-policy.html" target="_blank" rel="noopener noreferrer" class="form-options__link">個人情報保護方針</a>に同意する
                 </span>
             </label>
             <div id="terms-agree-error" class="form-group__error-message" role="alert"></div>
@@ -1487,7 +1490,7 @@
       const loginTermsAgreeError = document.getElementById('login-terms-agree-error');
       const loginButton = loginForm.querySelector('.button--filled');
       const googleButtonMain = document.querySelector('.form-container > .button--google');
-      const signupButtonMain = document.querySelector('.button--tonal');
+      const signupButtonMain = document.querySelector('[data-signup-trigger], .button--tonal');
       const modalOverlay = document.querySelector('.modal'); // BEM
       const modalContent = document.querySelector('.modal__content'); // BEM
       const modalCloseButton = document.querySelector('.modal__close-button'); // BEM
@@ -1507,6 +1510,33 @@
       const googleButtonModal = modalContent.querySelector('.button--google');
       const customerVoiceTeaserGrid = document.getElementById('customer-voice-teaser-grid');
       const customerVoiceTeaserStatus = document.getElementById('customer-voice-teaser-status');
+      const pageMain = document.querySelector('main');
+      const modalFocusableSelector = [
+        'a[href]',
+        'button:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+      ].join(',');
+      let modalReturnFocusElement = null;
+      let modalFocusTimeoutId = null;
+      function getModalFocusableElements() {
+        return Array.from(modalContent.querySelectorAll(modalFocusableSelector))
+          .filter((element) => element.offsetParent !== null);
+      }
+      function setBackgroundInert(isInert) {
+        if (!pageMain) {
+          return;
+        }
+        if (isInert) {
+          pageMain.setAttribute('aria-hidden', 'true');
+          pageMain.setAttribute('inert', '');
+          return;
+        }
+        pageMain.removeAttribute('aria-hidden');
+        pageMain.removeAttribute('inert');
+      }
       function resolveAppPath(relativePath) {
         if (!relativePath) {
           return relativePath;
@@ -1608,21 +1638,39 @@
       }
       // --- モーダルの表示/非表示関数 ---
       function showModal() {
+        modalReturnFocusElement = document.activeElement instanceof HTMLElement ? document.activeElement : signupButtonMain;
         modalOverlay.classList.remove('modal--is-hidden');
         document.body.classList.add('is-modal-open');
+        setBackgroundInert(true);
+        modalCloseButton?.focus({ preventScroll: true });
         // モーダルが表示されるアニメーションを考慮し、少し遅延させてからフォーカスを試みる
-        setTimeout(() => {
-          if (signupNameInput) {
-            signupNameInput.focus();
+        if (modalFocusTimeoutId) {
+          clearTimeout(modalFocusTimeoutId);
+        }
+        modalFocusTimeoutId = setTimeout(() => {
+          modalFocusTimeoutId = null;
+          if (modalOverlay.classList.contains('modal--is-hidden')) {
+            return;
           }
+          const focusableElements = getModalFocusableElements();
+          const firstFocusableElement = focusableElements[0] || signupNameInput || modalCloseButton;
+          firstFocusableElement?.focus();
         }, 100); // 100msの遅延
       }
       function hideModal() {
         modalOverlay.classList.add('modal--is-hidden');
         document.body.classList.remove('is-modal-open');
-        if (signupButtonMain) {
+        setBackgroundInert(false);
+        if (modalFocusTimeoutId) {
+          clearTimeout(modalFocusTimeoutId);
+          modalFocusTimeoutId = null;
+        }
+        if (modalReturnFocusElement && document.contains(modalReturnFocusElement)) {
+           modalReturnFocusElement.focus();
+        } else if (signupButtonMain) {
            signupButtonMain.focus();
         }
+        modalReturnFocusElement = null;
         clearSignupFormErrors();
         signupForm.reset();
       }
@@ -1710,8 +1758,29 @@
         modalCloseButton.addEventListener('click', hideModal);
       }
       document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && !modalOverlay.classList.contains('modal--is-hidden')) {
+        const isModalOpen = !modalOverlay.classList.contains('modal--is-hidden');
+        if (!isModalOpen) {
+          return;
+        }
+        if (event.key === 'Escape') {
           hideModal();
+          return;
+        }
+        if (event.key === 'Tab') {
+          const focusableElements = getModalFocusableElements();
+          if (!focusableElements.length) {
+            event.preventDefault();
+            return;
+          }
+          const firstFocusableElement = focusableElements[0];
+          const lastFocusableElement = focusableElements[focusableElements.length - 1];
+          if (event.shiftKey && document.activeElement === firstFocusableElement) {
+            event.preventDefault();
+            lastFocusableElement.focus();
+          } else if (!event.shiftKey && document.activeElement === lastFocusableElement) {
+            event.preventDefault();
+            firstFocusableElement.focus();
+          }
         }
       });
       if (showLoginLinkFromModal) {
@@ -1915,32 +1984,11 @@
     });
   </script>
 
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.9.7/jquery.fullpage.min.js"></script>
-  <script type="text/javascript">
-    $(document).ready(function() {
-      if(typeof $.fn.fullpage !== 'undefined') {
-        $('#fullpage').fullpage({
-          anchors: ['top', 'contents1', 'contents2', 'contents3', 'contents4', 'contents5', 'voices', 'contents6'],
-          navigation: true,
-          navigationPosition: 'right',
-          responsiveWidth: 1024,
-          scrollOverflow: false,
-          autoScrolling: true,
-          scrollingSpeed: 700,
-          fitToSection: true,
-          keyboardScrolling: true,
-          touchSensitivity: 15
-        });
-      }
-    });
-  </script>
-
 </body>
 </html>
 <!-- 自己チェックリスト -->
 <!-- コントラスト OK: 主要テキストと背景、ボタンとテキストのコントラストはWCAG AAを満たすようにカラー変数を設定済み（ツールで確認推奨） -->
-<!-- ランドマーク OK: role="main", role="dialog", aria-labelledby, aria-modal, aria-describedby など WAI-ARIA ロールを適切に配置 -->
+<!-- ランドマーク OK: main 要素、role="dialog", aria-labelledby, aria-modal, aria-describedby など WAI-ARIA ロールを適切に配置 -->
 <!-- レスポンシブ OK: @media クエリにより、sm, md, lg, xl のブレークポイントでレイアウトが適切に変化することを確認 -->
 <!-- 4px グリッド OK: margin, padding, font-size, border-radius など主要なサイズを4の倍数で定義・調整 -->
 <!-- 浮動ラベル削除 OK: 浮動ラベルのHTML構造とCSSルールを削除し、標準的なラベル配置に戻っていることを確認 -->


### PR DESCRIPTION
## Summary
- Address public login page review findings for focus visibility, signup modal keyboard handling, and duplicate main landmark.
- Reduce hero login card density and move signup to the primary LP CTA / small text link.
- Compress Section 7 related-service links so the footer signup CTA remains the final primary conversion path.

## Validation
- Confirmed no reintroduction of `127.0.0.1`, `fullPage(`, `new fullpage`, duplicate `role="main"`, or `href="index.html"` in the target files.
- Checked desktop, tablet, mobile, and short-mobile layouts for horizontal overflow and Section 7 clipping.
- Verified `?intent=signup#top` modal auto-open, Tab trap, Escape close, inert toggling, and focus restoration.
- Verified mock login routes for `user`, `new`, and `admin`.