### PR TITLE
feat: チュートリアルの改善（不具合修正・終盤フロー再構成・お試し導線）

### DIFF
--- a/05_support/common/footer.html
+++ b/05_support/common/footer.html
@@ -9,7 +9,7 @@
         <div class="support-footer__links">
           <a href="/help/">ヘルプ</a>
           <a href="/faq/">FAQ</a>
-          <a href="/tutorial/">チュートリアル</a>
+          <a href="/tutorial/?trial=1">チュートリアル</a>
           <a href="/bug-report/">お問い合わせ</a>
         </div>
       </div>

--- a/05_support/tutorial/src/tutorial/guards.js
+++ b/05_support/tutorial/src/tutorial/guards.js
@@ -5,7 +5,7 @@
 //   - isActive()                   : ?tutorial=1 が URL に付いているか
 //   - shouldBlock(action)          : チュートリアル中に本番ハンドラを止めるべきか
 //   - handleCreateSurveyFromModal  : 「作成する」差し替え（surveyCreation.html?tutorial=1&step=9 へ）
-//   - handleAttemptSave            : 「アンケートを作成」差し替え（QR ボタン有効化 → ステップ 18）
+//   - handleAttemptSave            : 「アンケートを保存する」差し替え（保存後 → ステップ 30 完了へ）
 //   - isCompleted()                : 完了フラグ
 //
 // 内部処理（チュートリアル進行の続行）は index.js から注入される _internal フック経由で行う。
@@ -81,14 +81,14 @@ const api = {
   },
 
   /**
-   * 「アンケートを作成」差し替え。本番ハンドラは showToast のみのためガード差し込みではなく、
-   * チュートリアル側で QR ボタン有効化＋ステップ 18 進行を実行する。
+   * 「アンケートを保存する」差し替え。本番ハンドラは showToast のみで画面遷移しないため、
+   * チュートリアル側で完了ステップ（30）への進行を実行する。
    */
   handleAttemptSave() {
     if (!isActiveNow()) return;
     enableQrButton();
     if (typeof internalHooks.goToStep === 'function') {
-      internalHooks.goToStep(18);
+      internalHooks.goToStep(30);
     }
   },
 

--- a/05_support/tutorial/src/tutorial/index.js
+++ b/05_support/tutorial/src/tutorial/index.js
@@ -20,6 +20,7 @@ import {
   repositionAll,
   showStuckHint,
   hideStuckHint,
+  showAccountCtaScreen,
 } from './overlay.js';
 import {
   readProgress,
@@ -27,6 +28,9 @@ import {
   clearProgress,
   markCompleted,
   isCompleted,
+  setEntryType,
+  getEntryType,
+  clearEntryType,
 } from './state.js';
 import { installGlobalApi, enableTargetForTutorial } from './guards.js';
 import { loadCommonHtml } from '../utils.js';
@@ -42,7 +46,8 @@ let bootstrapped = false;
 let lastInsertedQuestionEl = null;
 let questionObserver = null;
 let activeUserActionCleanup = null;
-let stuckHintTimerId = null; // G4: 6 秒後にヒント表示用
+let stuckHintTimerId = null; // G4: 4 秒後にヒント表示用
+let escapeTargetEl = null; // #18: 緊急脱出時に代行クリックする対象要素
 
 // ---------- 起動 ----------
 
@@ -73,7 +78,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     onComplete: handleComplete,
   });
 
-  installInterceptors();
   installNewQuestionObserver();
 
   const startStep = resolveStartStep();
@@ -83,10 +87,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   // 中断再開・URL での step 指定時はスキップして直接該当ステップへ。
   const progress = readProgress();
   const isFreshStart = !progress && startStep === 1;
+  // フレッシュ起動時のみエントリ種別を確定する。中断再開・ページ跨ぎでは
+  // 再設定しないため index.html→surveyCreation.html の遷移でも保持される。
+  if (isFreshStart) {
+    const isTrial = new URLSearchParams(window.location.search).get('trial') === '1';
+    setEntryType(isTrial ? 'trial' : 'standard');
+  }
   if (isFreshStart) {
     showWelcome({
       onStart: () => goToStep(1),
-      onSkip: () => showSkipConfirm(),
+      // welcome 画面自体が確認の役割を果たすため、確認モーダルを挟まず直接離脱する
+      onSkip: () => finishAndExit({ markComplete: true }),
     });
   } else {
     goToStep(startStep);
@@ -239,28 +250,25 @@ function applyBasicInfoHandoff() {
 function resolveTargetAndRender(step) {
   // ターゲットが waitForElement 指定なら出現を待つ
   const finalize = (targetEl) => {
+    const isUserAction = step.mode === 'user-action' || step.mode === 'user-action-bridge';
     // チュートリアル中の user-action 系ステップで対象が disabled の場合は強制 enable
-    if (targetEl && (step.mode === 'user-action' || step.mode === 'user-action-bridge')) {
+    if (targetEl && isUserAction) {
       if (targetEl.disabled === true || targetEl.getAttribute('aria-disabled') === 'true') {
         enableTargetForTutorial(targetEl);
       }
     }
     renderStep(step, targetEl);
+    // 救済: user-action 系で対象要素が取得できなかった場合、クリックリスナーも
+    // ヒントタイマーも張られず進行手段が無くなるため、即座にヒントを出して「次へ」を開放する。
+    // ただし完了ボタン付きステップ（最終ステップ）は「完了」ボタンが前進手段なので対象外。
+    if (!targetEl && isUserAction && !step.completeButtonLabel) {
+      showStuckHint('この操作はスキップできます。『次へ』で先に進めます');
+      return;
+    }
     applyStepBehavior(step, targetEl);
   };
 
   // 動的解決
-  if (step.targetResolver === 'lastInsertedQuestion') {
-    if (lastInsertedQuestionEl) {
-      finalize(lastInsertedQuestionEl);
-    } else {
-      // 直前ステップで挿入されたはずだが取得できなかった場合のフォールバック
-      const items = document.querySelectorAll('.question-card');
-      finalize(items.length > 0 ? items[items.length - 1] : null);
-    }
-    return;
-  }
-
   if (step.targetResolver === 'lastInsertedQuestionField') {
     let card = lastInsertedQuestionEl;
     if (!card) {
@@ -419,7 +427,7 @@ function bindUserActionListener(step, targetEl) {
   if (!targetEl) {
     return;
   }
-  // G4: クリック検出の救済 — 6 秒間クリックが無ければ吹き出しフッターにヒントを表示。
+  // G4: クリック検出の救済 — 4 秒間クリックが無ければ吹き出しフッターにヒントを表示。
   if (stuckHintTimerId) {
     window.clearTimeout(stuckHintTimerId);
     stuckHintTimerId = null;
@@ -427,23 +435,28 @@ function bindUserActionListener(step, targetEl) {
   stuckHintTimerId = window.setTimeout(() => {
     showStuckHint('ボタンが反応しないときは『次へ』で先に進めます');
     stuckHintTimerId = null;
-  }, 6000);
+    // #18: ヒント表示後の「次へ」緊急脱出で本来のクリックを代行できるよう対象を保持
+    escapeTargetEl = targetEl;
+  }, 4000);
+
+  // M-4: クリック前の .question-card 件数を控えておき、増加を検出してから記録する
+  const cardCountBeforeClick = document.querySelectorAll('.question-card').length;
 
   const handler = (ev) => {
-    // クリックが入ったらヒントタイマーは破棄
+    // クリックが入ったらヒントタイマー・緊急脱出対象は破棄
     if (stuckHintTimerId) {
       window.clearTimeout(stuckHintTimerId);
       stuckHintTimerId = null;
     }
+    escapeTargetEl = null;
     // user-action-bridge は本番ハンドラが guards 経由で進行を引き継ぐ
     // user-action はそのまま次ステップへ
     if (step.mode === 'user-action') {
       // 対象クリックは本来の動作（モーダルを開く、メニューを開く等）をそのまま走らせ、
-      // ステップ前進はマイクロタスク後に行う
-      window.setTimeout(() => {
-        captureLastInsertedQuestionIfNeeded(step);
+      // 設問カードの増加を検出してからステップ前進する
+      captureLastInsertedQuestionIfNeeded(step, cardCountBeforeClick, () => {
         advanceStep();
-      }, 50);
+      });
     }
   };
   targetEl.addEventListener('click', handler, { once: true });
@@ -464,15 +477,34 @@ function bindUserActionListener(step, targetEl) {
   };
 }
 
-function captureLastInsertedQuestionIfNeeded(step) {
+function captureLastInsertedQuestionIfNeeded(step, baselineCount, done) {
   // ステップ 12 / 19 のクリック直後に最新 .question-card を記録しておく
   // （新ステップ列でシングルアンサー選択=12, 評定尺度選択=19）
-  if (step.id === 12 || step.id === 19) {
-    const items = document.querySelectorAll('.question-card');
-    if (items.length > 0) {
-      lastInsertedQuestionEl = items[items.length - 1];
-    }
+  if (step.id !== 12 && step.id !== 19) {
+    done();
+    return;
   }
+  // M-4: renderAllQuestions が innerHTML 全消去→再生成するため固定待ちでは古いカードを掴む。
+  // .question-card 件数が baseline を超えるまでポーリング（最大 1 秒・50ms 間隔）して検出後に記録。
+  const start = Date.now();
+  const poll = () => {
+    const items = document.querySelectorAll('.question-card');
+    if (items.length > baselineCount) {
+      lastInsertedQuestionEl = items[items.length - 1];
+      done();
+      return;
+    }
+    if (Date.now() - start > 1000) {
+      // タイムアウト: 増加を検出できなくても末尾カードを安全側で記録して前進
+      if (items.length > 0) {
+        lastInsertedQuestionEl = items[items.length - 1];
+      }
+      done();
+      return;
+    }
+    window.setTimeout(poll, 50);
+  };
+  poll();
 }
 
 function cleanupActiveStep() {
@@ -485,6 +517,7 @@ function cleanupActiveStep() {
     window.clearTimeout(stuckHintTimerId);
     stuckHintTimerId = null;
   }
+  escapeTargetEl = null;
   hideStuckHint();
   clearReadonlyTracking();
 }
@@ -492,6 +525,19 @@ function cleanupActiveStep() {
 // ---------- 進行コールバック ----------
 
 function handleNext() {
+  // #18: 緊急脱出（stuck hint 経由の前進）時、対象要素が存在すれば本来のクリックを
+  // 代行してから前進する。対象が無ければ前進のみ。
+  if (escapeTargetEl) {
+    const el = escapeTargetEl;
+    escapeTargetEl = null;
+    if (document.body.contains(el)) {
+      try {
+        el.click();
+      } catch (_e) {
+        /* noop: クリック失敗時も前進は継続 */
+      }
+    }
+  }
   advanceStep();
 }
 
@@ -532,10 +578,21 @@ function advanceStep() {
 }
 
 function finishAndExit({ markComplete }) {
+  const isTrial = getEntryType() === 'trial';
   if (markComplete) markCompleted();
   else clearProgress();
-  destroyOverlay();
+  clearEntryType();
   detachNewQuestionObserver();
+  destroyOverlay();
+  // お試しユーザーは実ダッシュボードへ遷移せず、アカウント作成 CTA 画面へ誘導する。
+  // showAccountCtaScreen は内部で ensureRoot するため destroyOverlay 後に呼ぶ。
+  if (isTrial) {
+    showAccountCtaScreen({
+      onCreateAccount: () => window.location.assign('../../index.html?intent=signup'),
+      onClose: () => window.location.assign('../../index.html'),
+    });
+    return;
+  }
   // `05_support/tutorial/` 配下で動作するため、退出先は実ダッシュボードへ固定する
   window.location.assign('../../02_dashboard/index.html');
 }
@@ -548,13 +605,7 @@ function redirectWithTutorial(url, stepId) {
   window.location.assign(`${url}${sep}tutorial=1&step=${stepId}`);
 }
 
-// ---------- 本番ハンドラへの簡易インターセプト ----------
-
-function installInterceptors() {
-  // ステップ 11 / 14 のような「クリックで menu が出る」ステップで、出現後に
-  // 自動でステップを進めはしないが、menu 出現を検知して targetResolver で参照可能にする等の保守作業はここに集約する。
-  // 現状は何もしない（guards.js が本番ハンドラ側からの呼び出しを受ける）。
-}
+// ---------- 設問カード出現の監視 ----------
 
 function installNewQuestionObserver() {
   // 実画面の設問リストコンテナ ID は `questionListContainer`。見つからなければ body にフォールバック

--- a/05_support/tutorial/src/tutorial/overlay.js
+++ b/05_support/tutorial/src/tutorial/overlay.js
@@ -7,9 +7,14 @@ const SPOTLIGHT_RADIUS = 8;
 const PULSE_DURATION_MS = 200;
 const PULSE_COUNT = 2;
 const POSITION_TRANSITION_MS = 150;
+const MOBILE_BREAKPOINT = 768; // #6: この幅以下では right/left placement を不可とする
+const COACHMARK_FALLBACK_W = 400; // #8: CSS 実幅に合わせたフォールバック
+const COACHMARK_FALLBACK_H = 200; // #9: CSS 実高に寄せたフォールバック
+const CONNECTOR_REACH = 24; // bottom/top コネクタが伸びる距離（#25 のクランプ加味用）
 
 let rootEl = null; // .tutorial-root
 let maskEl = null; // .tutorial-mask（SVG 切り抜き）
+let cutoutRectEl = null; // SVG 切り抜き rect（#10: transition 統一のため保持）
 let spotlightEl = null; // .tutorial-spotlight（枠）
 let coachmarkEl = null; // .tutorial-coachmark
 let pointerEl = null; // .tutorial-pointer
@@ -18,7 +23,7 @@ let skipModalEl = null; // .tutorial-skip-modal
 let welcomeScreenEl = null; // .tutorial-welcome
 let progressStepLabelEl = null;
 let progressFillEl = null;
-let coachmarkStepBadgeEl = null;
+let srLiveEl = null; // #12: aria-live SR 専用領域
 
 let currentTargetEl = null;
 let currentStep = null;
@@ -26,9 +31,14 @@ let totalSteps = 20;
 let trackedReadonlyInputs = []; // {el, originalReadonly}
 let resizeHandlerBound = null;
 let scrollHandlerBound = null;
+let scrollRafId = null; // #21: scroll スロットル用 rAF id
 let windowClickGuardBound = null;
+let coachmarkKeydownBound = null; // #3/#4: コーチマーク内キーボード処理
+let animationSettleHandlerBound = null; // 対象の transition/animation 完了追従
 let pulseTimerId = null;
 let targetWatchObserver = null; // G9: 対象要素消失監視
+let targetResizeObserver = null; // 対象要素のサイズ変化（モーダル展開等）追従
+let inertedSiblings = []; // #3: inert を付与した body 直下要素
 
 let onNextCb = null;
 let onPrevCb = null;
@@ -46,20 +56,72 @@ export function initOverlay({ total } = {}) {
   buildCoachmark();
   buildPointer();
   resizeHandlerBound = () => repositionAll();
-  scrollHandlerBound = () => repositionAll();
+  // #21: scroll は capture + 全要素再計算が重いため requestAnimationFrame でスロットルする。
+  scrollHandlerBound = () => {
+    if (scrollRafId != null) return;
+    scrollRafId = window.requestAnimationFrame(() => {
+      scrollRafId = null;
+      repositionAll();
+    });
+  };
   window.addEventListener('resize', resizeHandlerBound);
   window.addEventListener('scroll', scrollHandlerBound, true);
+
+  // #3/#4: コーチマーク表示中のキーボード処理。
+  //   - Tab/Shift+Tab はコーチマーク内でフォーカスを循環（フォーカストラップ）
+  //   - ESC は離脱導線として skip 確認モーダルを開く
+  coachmarkKeydownBound = (ev) => {
+    // skip モーダル表示中は当該モーダルの keydown に委ねる（ESC=続ける挙動を維持）
+    if (skipModalEl || welcomeScreenEl) return;
+    if (!coachmarkEl || coachmarkEl.style.display === 'none') return;
+    if (ev.key === 'Escape') {
+      ev.preventDefault();
+      showSkipConfirm();
+      return;
+    }
+    if (ev.key === 'Tab') {
+      handleCoachmarkTab(ev);
+    }
+  };
+  document.addEventListener('keydown', coachmarkKeydownBound, true);
 
   // 対象外クリックを capture phase で判定。スポットライト対象とチュートリアル UI のみ通す。
   windowClickGuardBound = (ev) => {
     if (!currentTargetEl) return;
+    // プログラム的なクリック（チュートリアル自身が行う「選択肢を追加」ボタンの
+    // click() 等）はガード対象外。ユーザーの実クリック（isTrusted=true）だけを誘導する。
+    if (!ev.isTrusted) return;
     if (rootEl && rootEl.contains(ev.target)) return; // チュートリアル UI（吹き出し等）はそのまま
-    if (currentTargetEl === ev.target || currentTargetEl.contains(ev.target)) return; // 対象要素は通す
+    // 対象要素のクリックを通すのは user-action 系ステップのみ。
+    // info / autofill ステップは「次へ」で進む想定。対象がモーダル等のコンテナのとき、
+    // 内部のボタン（「作成する」等）を押して工程を飛ばすのを防ぐ。
+    const isUserActionStep = currentStep
+      && (currentStep.mode === 'user-action' || currentStep.mode === 'user-action-bridge');
+    if (isUserActionStep && (currentTargetEl === ev.target || currentTargetEl.contains(ev.target))) {
+      return; // 対象要素は通す
+    }
     ev.preventDefault();
     ev.stopPropagation();
     pulseAttention();
   };
   window.addEventListener('click', windowClickGuardBound, true);
+
+  // 対象要素の CSS トランジション/アニメーション完了時に再配置する。
+  // ResizeObserver は transform を検知しないため、モーダルの scale 展開アニメ等は
+  // こちらで完了を捉えてスポットライト枠・吹き出しを最終位置へ補正する。
+  animationSettleHandlerBound = (ev) => {
+    if (!currentTargetEl) return;
+    const t = ev.target;
+    if (
+      t === currentTargetEl
+      || (currentTargetEl.contains && currentTargetEl.contains(t))
+      || (t && t.contains && t.contains(currentTargetEl))
+    ) {
+      repositionAll();
+    }
+  };
+  document.addEventListener('transitionend', animationSettleHandlerBound, true);
+  document.addEventListener('animationend', animationSettleHandlerBound, true);
 
   // G9: 対象要素が DOM から切り離されたら再解決を試み、駄目なら中央フォールバック。
   targetWatchObserver = new MutationObserver(() => {
@@ -75,34 +137,65 @@ export function initOverlay({ total } = {}) {
         return;
       }
     }
-    // 再解決失敗 → スポットライト非表示・吹き出し中央
+    // #5: 再解決失敗 → スポットライト非表示・吹き出し中央。
+    // 暗幕だけ残って手がかりが消えるのを防ぐため、本文にメッセージを出し「次へ」を開放する。
     currentTargetEl = null;
     repositionAll();
+    showStuckHint('対象が見つかりません。「次へ」で進めます。');
   });
   targetWatchObserver.observe(document.body, { childList: true, subtree: true });
+
+  // 対象要素のサイズ変化（モーダルの展開アニメーション、遅延レイアウト等）に追従して
+  // 再配置する。描画時にレイアウト未確定でも、確定後の resize でスポットライト枠・
+  // 吹き出しが正しい位置へ補正される。
+  if (typeof ResizeObserver !== 'undefined') {
+    targetResizeObserver = new ResizeObserver(() => repositionAll());
+  }
 }
 
 export function destroyOverlay() {
   if (resizeHandlerBound) window.removeEventListener('resize', resizeHandlerBound);
   if (scrollHandlerBound) window.removeEventListener('scroll', scrollHandlerBound, true);
   if (windowClickGuardBound) window.removeEventListener('click', windowClickGuardBound, true);
+  if (coachmarkKeydownBound) document.removeEventListener('keydown', coachmarkKeydownBound, true);
+  if (animationSettleHandlerBound) {
+    document.removeEventListener('transitionend', animationSettleHandlerBound, true);
+    document.removeEventListener('animationend', animationSettleHandlerBound, true);
+    animationSettleHandlerBound = null;
+  }
+  if (scrollRafId != null) {
+    window.cancelAnimationFrame(scrollRafId);
+    scrollRafId = null;
+  }
   // G9: MutationObserver 停止
   if (targetWatchObserver) {
     targetWatchObserver.disconnect();
     targetWatchObserver = null;
   }
+  if (targetResizeObserver) {
+    targetResizeObserver.disconnect();
+    targetResizeObserver = null;
+  }
+  // #3: 背後ページの inert を確実に解除
+  releaseBackgroundInert();
   clearReadonlyTracking();
   if (rootEl?.parentNode) rootEl.parentNode.removeChild(rootEl);
   rootEl = null;
   maskEl = null;
+  cutoutRectEl = null;
   spotlightEl = null;
   coachmarkEl = null;
   pointerEl = null;
   progressBarEl = null;
   skipModalEl = null;
+  welcomeScreenEl = null;
   progressStepLabelEl = null;
   progressFillEl = null;
-  coachmarkStepBadgeEl = null;
+  srLiveEl = null;
+  resizeHandlerBound = null;
+  scrollHandlerBound = null;
+  windowClickGuardBound = null;
+  coachmarkKeydownBound = null;
   currentTargetEl = null;
   currentStep = null;
 }
@@ -120,11 +213,18 @@ export function renderStep(step, targetEl) {
   hideStuckHint();
   currentStep = step;
   currentTargetEl = targetEl;
+  // 対象のサイズ変化に追従させる（モーダル等が展開しきった後に枠を補正）。
+  if (targetResizeObserver) {
+    targetResizeObserver.disconnect();
+    if (targetEl) targetResizeObserver.observe(targetEl);
+  }
   updateProgress(step.id);
   if (targetEl) scrollIntoViewIfNeeded(targetEl);
   updateMaskAndSpotlight(targetEl);
   updateCoachmark(step, targetEl);
   updatePointer(step, targetEl);
+  // #12: ステップ遷移を SR へ通知（タイトル＋本文相当）
+  announceStep(step);
   trapFocus();
 }
 
@@ -243,13 +343,18 @@ export function showSkipConfirm() {
   if (skipModalEl) return;
   skipModalEl = buildSkipModal();
   rootEl.appendChild(skipModalEl);
-  const confirmBtn = skipModalEl.querySelector('[data-skip-action="confirm"]');
-  confirmBtn?.focus();
+  // #19: 離脱を後押ししないよう、初期フォーカスは「続ける」(cancel) に置く。
+  const cancelBtn = skipModalEl.querySelector('[data-skip-action="cancel"]');
+  try { cancelBtn?.focus(); } catch (_e) { /* noop */ }
 }
 
 export function hideSkipConfirm() {
   if (skipModalEl?.parentNode) skipModalEl.parentNode.removeChild(skipModalEl);
   skipModalEl = null;
+  // skip モーダルを閉じたらコーチマークへフォーカスを戻し、トラップを継続させる。
+  if (coachmarkEl && coachmarkEl.style.display !== 'none') {
+    trapFocus();
+  }
 }
 
 export function showWelcome({ onStart, onSkip } = {}) {
@@ -257,6 +362,13 @@ export function showWelcome({ onStart, onSkip } = {}) {
   ensureRoot();
   welcomeScreenEl = buildWelcomeScreen();
   rootEl.appendChild(welcomeScreenEl);
+  // #27: welcome 自身が dialog/aria-modal を持つ間、rootEl の dialog ロールは外して
+  // モーダルの二重ネストを解消する（#11 と整合）。
+  rootEl.removeAttribute('role');
+  rootEl.removeAttribute('aria-modal');
+  rootEl.removeAttribute('aria-label');
+  // #3: welcome 表示中も背後ページを inert 化する
+  applyBackgroundInert();
   // 進行バー・マスク等の通常チュートリアル UI は非表示にして welcome に集中させる
   if (progressBarEl) progressBarEl.style.display = 'none';
   if (maskEl) maskEl.style.display = 'none';
@@ -279,12 +391,48 @@ export function showWelcome({ onStart, onSkip } = {}) {
 export function hideWelcome() {
   if (welcomeScreenEl?.parentNode) welcomeScreenEl.parentNode.removeChild(welcomeScreenEl);
   welcomeScreenEl = null;
+  // #3: welcome フェーズで付与した背後ページの inert を解除する。
+  // コーチマーク表示フェーズでは user-action 対象をクリックさせるため inert を残さない。
+  releaseBackgroundInert();
+  // #27: welcome 終了後、rootEl の dialog ロールを復元（コーチマーク表示フェーズ）
+  rootEl?.setAttribute('role', 'dialog');
+  rootEl?.setAttribute('aria-modal', 'true');
+  rootEl?.setAttribute('aria-label', 'SPEED AD チュートリアル');
   // 通常チュートリアル UI を復活
   if (progressBarEl) progressBarEl.style.display = '';
   if (maskEl) maskEl.style.display = '';
   if (coachmarkEl) coachmarkEl.style.display = '';
   if (spotlightEl) spotlightEl.style.display = '';
   if (pointerEl) pointerEl.style.display = '';
+}
+
+/**
+ * チュートリアル完了/スキップ後、アカウント未保有のお試しユーザー向けに表示する
+ * 全画面 CTA 画面。index.js が finishAndExit 内で destroyOverlay() を呼んだ後に
+ * 呼び出すため、rootEl は破棄済み。自前で ensureRoot() してルートを用意する。
+ * 終端画面のため 1 回表示のみで冪等化・hide 関数は持たない。
+ */
+export function showAccountCtaScreen({ onCreateAccount, onClose } = {}) {
+  ensureRoot();
+  const ctaScreenEl = buildAccountCtaScreen();
+  rootEl.appendChild(ctaScreenEl);
+  // CTA 画面自身が dialog/aria-modal を持つため、rootEl の dialog ロールは外して
+  // モーダルの二重ネストを解消する（welcome と同じ作法）。
+  rootEl.removeAttribute('role');
+  rootEl.removeAttribute('aria-modal');
+  rootEl.removeAttribute('aria-label');
+  // 背後ページを inert 化して操作不能にする。
+  applyBackgroundInert();
+
+  const createBtn = ctaScreenEl.querySelector('.tutorial-account-cta__create');
+  const closeBtn = ctaScreenEl.querySelector('.tutorial-account-cta__close');
+  createBtn?.addEventListener('click', () => {
+    onCreateAccount && onCreateAccount();
+  });
+  closeBtn?.addEventListener('click', () => {
+    onClose && onClose();
+  });
+  createBtn?.focus();
 }
 
 // ---------- 構築 ----------
@@ -296,7 +444,17 @@ function ensureRoot() {
   rootEl.setAttribute('role', 'dialog');
   rootEl.setAttribute('aria-modal', 'true');
   rootEl.setAttribute('aria-label', 'SPEED AD チュートリアル');
+  // #11: コーチマークのタイトル/本文を dialog のラベル・説明として参照する。
+  rootEl.setAttribute('aria-labelledby', 'tutorial-coachmark-title');
+  rootEl.setAttribute('aria-describedby', 'tutorial-coachmark-body');
   document.body.appendChild(rootEl);
+
+  // #12: ステップ遷移を読み上げる SR 専用領域。CSS（tutorial-sr-only）は別担当が定義。
+  srLiveEl = document.createElement('div');
+  srLiveEl.className = 'tutorial-sr-only';
+  srLiveEl.setAttribute('aria-live', 'polite');
+  srLiveEl.setAttribute('aria-atomic', 'true');
+  rootEl.appendChild(srLiveEl);
 }
 
 function buildProgressBar() {
@@ -358,6 +516,12 @@ function buildMask() {
   cutout.setAttribute('rx', String(SPOTLIGHT_RADIUS));
   cutout.setAttribute('ry', String(SPOTLIGHT_RADIUS));
   cutout.setAttribute('fill', 'black');
+  // #10: spotlightEl(枠) は CSS transition で 150ms 補間されるため、
+  // SVG cutout rect の x/y/width/height にも同じ transition を付けてジャンプを揃える。
+  cutout.style.transition =
+    `x ${POSITION_TRANSITION_MS}ms ease-out, y ${POSITION_TRANSITION_MS}ms ease-out, ` +
+    `width ${POSITION_TRANSITION_MS}ms ease-out, height ${POSITION_TRANSITION_MS}ms ease-out`;
+  cutoutRectEl = cutout;
   mask.appendChild(cutout);
   defs.appendChild(mask);
   svg.appendChild(defs);
@@ -382,25 +546,25 @@ function buildMask() {
 function buildCoachmark() {
   coachmarkEl = document.createElement('div');
   coachmarkEl.className = 'tutorial-coachmark';
-  coachmarkEl.setAttribute('role', 'dialog');
+  // #11: role="dialog" は rootEl が保持するため、コーチマーク側からは外して二重ネストを解消。
+  // タイトル/本文へ id を付与し、rootEl が aria-labelledby/describedby で参照する。
+  coachmarkEl.setAttribute('tabindex', '-1'); // #7: 安全な初期フォーカス先
 
   const headerEl = document.createElement('div');
   headerEl.className = 'tutorial-coachmark__header';
 
-  const stepBadgeEl = document.createElement('span');
-  stepBadgeEl.className = 'tutorial-coachmark__step-badge';
-  stepBadgeEl.textContent = `${padStep(1)} / ${padStep(totalSteps)}`;
-  coachmarkStepBadgeEl = stepBadgeEl;
-  headerEl.appendChild(stepBadgeEl);
+  // #13: コーチマーク内 step-badge は廃止（進行バーへ一本化）。
 
   const titleEl = document.createElement('h2');
   titleEl.className = 'tutorial-coachmark__title';
+  titleEl.id = 'tutorial-coachmark-title';
   headerEl.appendChild(titleEl);
 
   coachmarkEl.appendChild(headerEl);
 
   const bodyEl = document.createElement('p');
   bodyEl.className = 'tutorial-coachmark__body';
+  bodyEl.id = 'tutorial-coachmark-body';
   coachmarkEl.appendChild(bodyEl);
 
   const footer = document.createElement('div');
@@ -439,7 +603,8 @@ function buildCoachmark() {
 
   const hint = document.createElement('span');
   hint.className = 'tutorial-coachmark__hint';
-  hint.textContent = 'クリックして次へ';
+  // #15: 押す対象を明示する文言にする。
+  hint.textContent = 'ハイライトされた箇所をクリックしてください';
   footer.appendChild(hint);
 
   coachmarkEl.appendChild(footer);
@@ -485,7 +650,8 @@ function buildSkipModal() {
 
   const body = document.createElement('p');
   body.className = 'tutorial-skip-modal__body';
-  body.textContent = '終了するとアンケート一覧画面に移動します。';
+  // #28: 実遷移先はステップ 1（ダッシュボード）。呼称をステップ 1 と揃える。
+  body.textContent = '終了するとダッシュボードに移動します。';
   panel.appendChild(body);
 
   const footer = document.createElement('div');
@@ -550,7 +716,8 @@ function buildWelcomeScreen() {
 
   const body = document.createElement('p');
   body.className = 'tutorial-welcome__body';
-  body.textContent = 'アンケート作成から QR 発行までの基本フローを、5 分ほどで体験しましょう。';
+  // #29: 26 ステップの実所要と乖離するため、断定を避けた控えめな表現にする。
+  body.textContent = 'アンケート作成から QR 発行までの基本フローを、数分で体験しましょう。';
   panel.appendChild(body);
 
   const actions = document.createElement('div');
@@ -576,6 +743,55 @@ function buildWelcomeScreen() {
   return overlay;
 }
 
+function buildAccountCtaScreen() {
+  const overlay = document.createElement('div');
+  overlay.className = 'tutorial-account-cta';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-labelledby', 'tutorial-account-cta-title');
+
+  const panel = document.createElement('div');
+  panel.className = 'tutorial-account-cta__panel';
+
+  const eyebrow = document.createElement('div');
+  eyebrow.className = 'tutorial-account-cta__eyebrow';
+  eyebrow.textContent = 'SPEED AD';
+  panel.appendChild(eyebrow);
+
+  const title = document.createElement('h1');
+  title.className = 'tutorial-account-cta__title';
+  title.id = 'tutorial-account-cta-title';
+  title.textContent = 'アカウントを作成して、はじめましょう';
+  panel.appendChild(title);
+
+  const body = document.createElement('p');
+  body.className = 'tutorial-account-cta__body';
+  body.textContent =
+    'ここまでがアンケート作成の基本フローです。アカウントを作成すると、'
+    + '実際にアンケートを公開して回答を集められます。';
+  panel.appendChild(body);
+
+  const actions = document.createElement('div');
+  actions.className = 'tutorial-account-cta__actions';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'tutorial-account-cta__close';
+  closeBtn.textContent = '閉じる';
+  actions.appendChild(closeBtn);
+
+  const createBtn = document.createElement('button');
+  createBtn.type = 'button';
+  createBtn.className = 'tutorial-account-cta__create';
+  createBtn.textContent = 'アカウントを作成';
+  actions.appendChild(createBtn);
+
+  panel.appendChild(actions);
+  overlay.appendChild(panel);
+
+  return overlay;
+}
+
 // ---------- 更新 ----------
 
 function padStep(n) {
@@ -583,11 +799,9 @@ function padStep(n) {
 }
 
 function updateProgress(stepId) {
+  // #13: 進捗表示は進行バーへ一本化（コーチマーク内 step-badge は廃止）。
   if (progressStepLabelEl) {
     progressStepLabelEl.textContent = `${padStep(stepId)} / ${padStep(totalSteps)}`;
-  }
-  if (coachmarkStepBadgeEl) {
-    coachmarkStepBadgeEl.textContent = `${padStep(stepId)} / ${padStep(totalSteps)}`;
   }
   if (progressFillEl) {
     const pct = Math.min(100, Math.max(0, (stepId / totalSteps) * 100));
@@ -596,7 +810,7 @@ function updateProgress(stepId) {
 }
 
 function updateMaskAndSpotlight(targetEl) {
-  const cutout = maskEl?.querySelector('#tutorial-mask-cutout-rect');
+  const cutout = cutoutRectEl || maskEl?.querySelector('#tutorial-mask-cutout-rect');
   if (!cutout || !spotlightEl) return;
 
   if (!targetEl) {
@@ -654,40 +868,24 @@ function updateCoachmark(step, targetEl) {
     hint.style.display = isUserAction ? '' : 'none';
   }
 
-  // 「戻る」は先頭以外で表示
+  // 「戻る」は先頭以外で表示。M-2: ページ境界ステップ（step.hideBack）では非表示。
   if (prevBtn) {
-    prevBtn.style.display = step.id > 1 ? '' : 'none';
+    const showPrev = step.id > 1 && step.hideBack !== true;
+    prevBtn.style.display = showPrev ? '' : 'none';
   }
 
-  // 位置決め
+  // 位置決め。#9: 本文セット直後は高さが未確定なため、
+  // レイアウト確定後（次フレーム）に再度位置を計算してずれを補正する。
   positionCoachmark(step, targetEl);
+  window.requestAnimationFrame(() => {
+    if (currentStep === step) positionCoachmark(step, targetEl);
+  });
 }
 
-function positionCoachmark(step, targetEl) {
-  if (!coachmarkEl) return;
-  const placement = step.placement || 'bottom';
-  const notch = coachmarkEl.querySelector('.tutorial-coachmark__notch');
-  if (notch) notch.dataset.placement = placement;
-
-  // center placement または target なしの場合は画面中央
-  if (placement === 'center' || !targetEl) {
-    coachmarkEl.style.transition = `all ${POSITION_TRANSITION_MS}ms ease-out`;
-    coachmarkEl.style.left = '50%';
-    coachmarkEl.style.top = '50%';
-    coachmarkEl.style.transform = 'translate(-50%, -50%)';
-    if (notch) notch.style.display = 'none';
-    return;
-  }
-  if (notch) notch.style.display = '';
-
-  const rect = targetEl.getBoundingClientRect();
-  const cmRect = coachmarkEl.getBoundingClientRect();
-  const coachmarkW = cmRect.width || 320;
-  const coachmarkH = cmRect.height || 160;
-  const gap = 16;
+// 指定 placement での吹き出し左上座標を計算する（クランプ前の素の値）。
+function computeRawPosition(placement, rect, coachmarkW, coachmarkH, gap) {
   let left = 0;
   let top = 0;
-
   switch (placement) {
     case 'top':
       left = rect.left + rect.width / 2 - coachmarkW / 2;
@@ -707,19 +905,144 @@ function positionCoachmark(step, targetEl) {
       top = rect.bottom + gap;
       break;
   }
+  return { left, top };
+}
 
-  // G8: 吹き出しの画面内クランプ
-  //   - top: 進行バー 48px + 余白 8px = 56px を下端、画面高 - 高さ - 8px を上端
-  //   - left: 8px を左端、画面幅 - 幅 - 8px を右端
+// 2 つの矩形（left/top/width/height）が重なるか判定する。
+function rectsOverlap(a, b) {
+  return (
+    a.left < b.left + b.width &&
+    a.left + a.width > b.left &&
+    a.top < b.top + b.height &&
+    a.top + a.height > b.top
+  );
+}
+
+function positionCoachmark(step, targetEl) {
+  if (!coachmarkEl) return;
+  const notch = coachmarkEl.querySelector('.tutorial-coachmark__notch');
+
+  // center placement または target なしの場合は画面中央
+  let placement = step.placement || 'bottom';
+  if (placement === 'center' || !targetEl) {
+    if (notch) {
+      notch.dataset.placement = 'center';
+      notch.style.display = 'none';
+      notch.style.left = '';
+      notch.style.top = '';
+      notch.style.transform = '';
+    }
+    coachmarkEl.style.transition = `all ${POSITION_TRANSITION_MS}ms ease-out`;
+    coachmarkEl.style.left = '50%';
+    coachmarkEl.style.top = '50%';
+    coachmarkEl.style.transform = 'translate(-50%, -50%)';
+    return;
+  }
+
   const vw = window.innerWidth;
   const vh = window.innerHeight;
-  top = Math.max(56, Math.min(top, vh - coachmarkH - 8));
-  left = Math.max(8, Math.min(left, vw - coachmarkW - 8));
+  const rect = targetEl.getBoundingClientRect();
+  const cmRect = coachmarkEl.getBoundingClientRect();
+  // #8/#9: フォールバックを CSS 実寸（幅 400 / 高さ 200+）に合わせる。
+  const coachmarkW = cmRect.width || COACHMARK_FALLBACK_W;
+  const coachmarkH = cmRect.height || COACHMARK_FALLBACK_H;
+  const gap = 16;
+
+  // #6: モバイル幅では right/left を不可とし bottom/top に倒す。
+  // 対象が画面下寄り（下側に吹き出しが収まらない）なら top、それ以外は bottom。
+  if (vw <= MOBILE_BREAKPOINT && (placement === 'right' || placement === 'left')) {
+    const fitsBelow = rect.bottom + gap + coachmarkH <= vh - 8;
+    placement = fitsBelow ? 'bottom' : 'top';
+  }
+
+  // #1: 候補 placement を順に試し、ターゲットと重ならず画面内に収まる配置を選ぶ。
+  //   right↔left, top↔bottom の反対側をフォールバック候補に含める。
+  const opposite = { right: 'left', left: 'right', top: 'bottom', bottom: 'top' };
+  const candidates = [placement];
+  if (opposite[placement]) candidates.push(opposite[placement]);
+
+  const targetBox = {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+
+  let chosen = null;
+  let firstPos = null;
+  for (let i = 0; i < candidates.length; i += 1) {
+    const cand = candidates[i];
+    const pos = computeRawPosition(cand, rect, coachmarkW, coachmarkH, gap);
+    if (i === 0) firstPos = { placement: cand, ...pos };
+    const onScreen =
+      pos.left >= 8 &&
+      pos.left + coachmarkW <= vw - 8 &&
+      pos.top >= 56 &&
+      pos.top + coachmarkH <= vh - 8;
+    const box = { left: pos.left, top: pos.top, width: coachmarkW, height: coachmarkH };
+    if (onScreen && !rectsOverlap(box, targetBox)) {
+      chosen = { placement: cand, ...pos };
+      break;
+    }
+  }
+  // どの候補も収まらない場合は最初の候補を使う（クランプで可能な限り見せる）。
+  if (!chosen) chosen = firstPos;
+
+  placement = chosen.placement;
+  let { left, top } = chosen;
+
+  if (notch) {
+    notch.dataset.placement = placement;
+    notch.style.display = '';
+  }
+
+  // G8/#25: 吹き出しの画面内クランプ。
+  //   - top: 進行バー 48px + 余白 8px = 56px を下端。
+  //     bottom placement はコネクタが上へ伸びるため、その分（CONNECTOR_REACH）下げて
+  //     コネクタが進行バーへ食い込まないようにする。
+  //   - left: 8px を左端、画面幅 - 幅 - 8px を右端。
+  const topFloor = placement === 'bottom' ? 56 + CONNECTOR_REACH : 56;
+  const clampedTop = Math.max(topFloor, Math.min(top, vh - coachmarkH - 8));
+  const clampedLeft = Math.max(8, Math.min(left, vw - coachmarkW - 8));
+  top = clampedTop;
+  left = clampedLeft;
 
   coachmarkEl.style.transition = `all ${POSITION_TRANSITION_MS}ms ease-out`;
   coachmarkEl.style.transform = 'none';
   coachmarkEl.style.left = `${left}px`;
   coachmarkEl.style.top = `${top}px`;
+
+  // #2: クランプで吹き出しがずれてもコネクタがターゲット中心を指すよう、JS で動的補正。
+  adjustConnector(notch, placement, rect, left, top, coachmarkW, coachmarkH);
+}
+
+/**
+ * #2: コネクタ（ノッチ）位置の動的補正。
+ * CSS は left:50% 等の固定配置だが、クランプで吹き出しがずれるとターゲットを指さなくなる。
+ * top/bottom placement は水平方向、left/right placement は垂直方向のオフセットを
+ * 吹き出し座標基準に再計算し、ターゲット中心へ向ける。
+ */
+function adjustConnector(notch, placement, targetRect, cmLeft, cmTop, cmW, cmH) {
+  if (!notch) return;
+  const targetCx = targetRect.left + targetRect.width / 2;
+  const targetCy = targetRect.top + targetRect.height / 2;
+  const edgePad = 12; // コネクタが吹き出し角からはみ出さないための余白
+
+  if (placement === 'top' || placement === 'bottom') {
+    // 吹き出し内 X 座標としてターゲット中心を表現し、両端を edgePad でクランプ。
+    let connLeft = targetCx - cmLeft;
+    connLeft = Math.max(edgePad, Math.min(connLeft, cmW - edgePad));
+    notch.style.left = `${connLeft}px`;
+    notch.style.top = '';
+    notch.style.transform = 'translateX(-50%)';
+  } else {
+    // left / right placement: 垂直方向を補正。
+    let connTop = targetCy - cmTop;
+    connTop = Math.max(edgePad, Math.min(connTop, cmH - edgePad));
+    notch.style.top = `${connTop}px`;
+    notch.style.left = '';
+    notch.style.transform = 'translateY(-50%)';
+  }
 }
 
 function updatePointer(step, targetEl) {
@@ -740,11 +1063,112 @@ function updatePointer(step, targetEl) {
   pointerEl.style.pointerEvents = 'none';
 }
 
+/**
+ * #3: コーチマーク内のフォーカス可能要素一覧を返す（display:none のものは除外）。
+ */
+function getCoachmarkFocusable() {
+  if (!coachmarkEl) return [];
+  const nodes = coachmarkEl.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+  );
+  return Array.prototype.filter.call(nodes, (el) => {
+    if (el.disabled) return false;
+    if (el.style.display === 'none') return false;
+    // 祖先まで遡って非表示でないか確認
+    return el.offsetParent !== null || el === document.activeElement;
+  });
+}
+
+/**
+ * #3/#7: Tab / Shift+Tab を完全手動で循環させるフォーカストラップ。
+ * コーチマーク内のフォーカス可能要素に加え、user-action ステップでは
+ * ハイライト対象も循環に含め、キーボードのみのユーザーが対象を直接操作できるようにする。
+ */
+function handleCoachmarkTab(ev) {
+  const focusable = getCoachmarkFocusable();
+  // #7: user-action 系ステップではハイライト対象もタブ循環に含める。
+  const isUserAction = currentStep
+    && (currentStep.mode === 'user-action' || currentStep.mode === 'user-action-bridge');
+  if (isUserAction && currentTargetEl && document.contains(currentTargetEl)) {
+    focusable.push(currentTargetEl);
+  }
+  if (focusable.length === 0) {
+    // フォーカス可能要素が無ければコーチマーク本体に留める。
+    ev.preventDefault();
+    try { coachmarkEl.focus({ preventScroll: true }); } catch (_e) { /* noop */ }
+    return;
+  }
+  // 完全手動循環: 常に next/prev を明示制御する。
+  ev.preventDefault();
+  const active = document.activeElement;
+  let idx = focusable.indexOf(active);
+  if (idx === -1) {
+    // コーチマーク本体(tabindex=-1)等、リスト外にフォーカスがある場合は端から開始。
+    idx = ev.shiftKey ? 0 : focusable.length - 1;
+  }
+  const nextIdx = ev.shiftKey
+    ? (idx - 1 + focusable.length) % focusable.length
+    : (idx + 1) % focusable.length;
+  try { focusable[nextIdx].focus({ preventScroll: true }); } catch (_e) { /* noop */ }
+}
+
+/**
+ * #3/#7: ステップ表示時の自動フォーカス。
+ *   - 「次へ」ボタンが表示されていればそこへ（#7: 「スキップ」へ当たって誤離脱するのを防ぐ）。
+ *   - user-action ステップで「次へ」非表示のときは「スキップ」を初期フォーカスせず、
+ *     コーチマーク本体（tabindex=-1）へフォーカスする。
+ */
 function trapFocus() {
   if (!coachmarkEl) return;
-  const focusable = coachmarkEl.querySelector('button:not([style*="display: none"])');
-  // 直近の自動フォーカスは「次へ」または「スキップ」
-  if (focusable) {
-    try { focusable.focus({ preventScroll: true }); } catch (_e) { /* noop */ }
+  const nextBtn = coachmarkEl.querySelector('.tutorial-coachmark__next');
+  let focusTarget = null;
+  if (nextBtn && nextBtn.style.display !== 'none') {
+    focusTarget = nextBtn;
+  } else {
+    focusTarget = coachmarkEl; // 安全な要素（スキップは避ける）
   }
+  try { focusTarget.focus({ preventScroll: true }); } catch (_e) { /* noop */ }
+}
+
+// ---------- #3: 背後ページの inert 制御 ----------
+
+/**
+ * tutorial-root 以外の body 直下要素へ inert を付与し、背後ページを操作不能にする。
+ * destroyOverlay で releaseBackgroundInert により確実に解除する。
+ */
+function applyBackgroundInert() {
+  if (!rootEl || !document.body) return;
+  const children = Array.prototype.slice.call(document.body.children);
+  children.forEach((el) => {
+    if (el === rootEl) return;
+    if (el.hasAttribute('inert')) return; // 既に inert（多重付与の冪等化）
+    if (inertedSiblings.indexOf(el) !== -1) return;
+    el.setAttribute('inert', '');
+    inertedSiblings.push(el);
+  });
+}
+
+function releaseBackgroundInert() {
+  inertedSiblings.forEach((el) => {
+    if (el && el.removeAttribute) el.removeAttribute('inert');
+  });
+  inertedSiblings = [];
+}
+
+// ---------- #12: SR 通知 ----------
+
+/**
+ * ステップ遷移時にタイトル＋本文相当を aria-live 領域へ流し込み、SR に通知する。
+ */
+function announceStep(step) {
+  if (!srLiveEl) return;
+  const title = step.title || '';
+  const body = step.body || '';
+  const stepLabel = `ステップ ${padStep(step.id)} / ${padStep(totalSteps)}`;
+  // 同一テキスト連続でも再通知されるよう一旦空にしてから設定する。
+  srLiveEl.textContent = '';
+  window.requestAnimationFrame(() => {
+    if (!srLiveEl) return;
+    srLiveEl.textContent = [stepLabel, title, body].filter(Boolean).join('。 ');
+  });
 }

--- a/05_support/tutorial/src/tutorial/state.js
+++ b/05_support/tutorial/src/tutorial/state.js
@@ -6,6 +6,7 @@
 
 const PROGRESS_KEY = 'speedad-tutorial-progress';
 const COMPLETED_KEY = 'speedad-tutorial-completed';
+const ENTRY_KEY = 'speedad-tutorial-entry';
 
 function safeGetItem(key) {
   try {
@@ -64,7 +65,20 @@ export function isCompleted() {
   return safeGetItem(COMPLETED_KEY) === '1';
 }
 
+export function setEntryType(type) {
+  safeSetItem(ENTRY_KEY, type);
+}
+
+export function getEntryType() {
+  return safeGetItem(ENTRY_KEY);
+}
+
+export function clearEntryType() {
+  safeRemoveItem(ENTRY_KEY);
+}
+
 export function resetAll() {
   safeRemoveItem(PROGRESS_KEY);
   safeRemoveItem(COMPLETED_KEY);
+  safeRemoveItem(ENTRY_KEY);
 }

--- a/05_support/tutorial/src/tutorial/steps.js
+++ b/05_support/tutorial/src/tutorial/steps.js
@@ -1,8 +1,8 @@
 // steps.js
-// チュートリアル全 26 ステップ定義（仕様書 §4 参照）
+// チュートリアル全 30 ステップ定義（仕様書 §4 参照）
 //
 // 各ステップフィールド:
-//   id        : ステップ番号（1..26）
+//   id        : ステップ番号（1..30）
 //   block     : 'A' | 'B' | 'C' | 'D'
 //   target    : 対象要素 CSS セレクタ（null の場合は画面中央 or 動的解決）
 //   mode      : 'info' | 'autofill' | 'user-action' | 'user-action-bridge'
@@ -17,8 +17,9 @@
 //   targetResolver : 'lastInsertedQuestionField' 等、動的にターゲットを解決する場合
 //   fieldPath / optionIndex : targetResolver='lastInsertedQuestionField' 時の解決パラメタ
 //
-// id=8, id=23, id=26 は user-action-bridge（本番ハンドラに代えてチュートリアルが続行処理を担う）。
+// id=8, id=29, id=30 は user-action-bridge（本番ハンドラに代えてチュートリアルが続行処理を担う）。
 // 旧 step 13（シングルアンサー一括）と旧 step 16（評定尺度一括）はフィールド単位に分解済み。
+// ブロック D（id=23..30）はプレビュー確認 → QR → 保存 → 完了 の順。
 
 const TOMORROW_OFFSET_DAYS = 1;
 const PERIOD_LENGTH_DAYS = 3;
@@ -43,7 +44,7 @@ export const TUTORIAL_STEPS = [
     target: null,
     mode: 'info',
     placement: 'center',
-    title: 'ダッシュボード',
+    title: 'アンケート作成の流れを学ぶ',
     body: 'ここがアンケートを管理する画面です。これからアンケート作成の流れを順番にご案内します。',
   },
   {
@@ -52,7 +53,7 @@ export const TUTORIAL_STEPS = [
     target: '#surveyTable',
     mode: 'info',
     placement: 'top',
-    title: 'アンケート一覧',
+    title: 'アンケート一覧を確認',
     body: 'ここがアンケート一覧です。作成済みアンケートが一覧表示されます。',
   },
   {
@@ -61,7 +62,7 @@ export const TUTORIAL_STEPS = [
     target: '#openNewSurveyModalBtn',
     mode: 'user-action',
     placement: 'bottom',
-    title: '新規作成ボタン',
+    title: '新規作成ボタンを押す',
     body: '右上の「アンケート新規作成」ボタンを押してください。',
   },
 
@@ -74,8 +75,8 @@ export const TUTORIAL_STEPS = [
     target: '#newSurveyModal .modal-content-transition',
     mode: 'info',
     placement: 'right',
-    title: '新規作成モーダル',
-    body: 'ここでアンケートの基本情報を入力します。',
+    title: '基本情報を入力する',
+    body: 'ここでアンケートの基本情報を入力します。今回は練習のため、こちらで自動入力していきます。',
     waitForElement: true,
   },
   {
@@ -84,8 +85,8 @@ export const TUTORIAL_STEPS = [
     target: '#newSurveyModal #surveyName',
     mode: 'autofill',
     placement: 'right',
-    title: 'アンケート名（管理用）',
-    body: 'ここがアンケート名（管理用）です。社内管理用の名前で、回答者には表示されません。練習のため「初めてのアンケート」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: 'アンケート名を入力',
+    body: '社内管理用の名前で、回答者には表示されません。練習のため「初めてのアンケート」を自動入力しました。',
     autoInput: { kind: 'text', value: '初めてのアンケート' },
   },
   {
@@ -94,8 +95,8 @@ export const TUTORIAL_STEPS = [
     target: '#newSurveyModal #displayTitle',
     mode: 'autofill',
     placement: 'right',
-    title: '表示タイトル（回答者表示）',
-    body: 'ここが表示タイトルです。回答者の画面に表示される名称です。練習のため「製品Aに関する満足度調査」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '表示タイトルを入力',
+    body: '回答者の画面に表示される名称です。練習のため「製品Aに関する満足度調査」を自動入力しました。',
     autoInput: { kind: 'text', value: '製品Aに関する満足度調査' },
   },
   {
@@ -104,8 +105,8 @@ export const TUTORIAL_STEPS = [
     target: '#newSurveyPeriodRange',
     mode: 'autofill',
     placement: 'right',
-    title: '回答期間',
-    body: 'ここが回答期間です。回答を受け付ける開始日と終了日を指定します。練習のため翌日から 3 日間を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '回答期間を設定',
+    body: '回答を受け付ける開始日と終了日を指定します。練習のため翌日から 3 日間を自動入力しました。',
     autoInput: { kind: 'flatpickr-range', getRange: buildPeriodRange },
   },
   {
@@ -115,7 +116,7 @@ export const TUTORIAL_STEPS = [
     mode: 'user-action-bridge',
     placement: 'top',
     title: '作成する（練習・保存されません）',
-    body: '内容を確認したら「作成する」ボタンを押してください。これは練習のため、実際のアンケート一覧には追加されません。続けて作成画面の使い方を見てみましょう。',
+    body: '内容を確認したら「作成する」ボタンを押してください。続けて作成画面の使い方を見てみましょう。',
   },
 
   // ------------------------------------------------------------
@@ -127,7 +128,8 @@ export const TUTORIAL_STEPS = [
     target: '#basicInfoBody',
     mode: 'info',
     placement: 'right',
-    title: '基本情報の反映確認',
+    hideBack: true,
+    title: '基本情報の反映を確認',
     body: '前の画面で入力した情報がここに反映されています。',
   },
   {
@@ -136,7 +138,7 @@ export const TUTORIAL_STEPS = [
     target: '#settings-column',
     mode: 'info',
     placement: 'left',
-    title: '設定カードの紹介',
+    title: '設定カードを確認',
     body: '名刺データ化・お礼メール・サンクス画面はここから個別に設定できます。今回はそのまま進みます。',
   },
   {
@@ -168,8 +170,8 @@ export const TUTORIAL_STEPS = [
     fieldPath: 'questionText',
     mode: 'autofill',
     placement: 'right',
-    title: 'シングルアンサーの設問文',
-    body: 'ここが設問文です。回答者に何を聞くかを書く欄です。練習のため「製品Aの満足度はいかがですか？」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '設問文を入力',
+    body: '回答者に何を聞くかを書く欄です。練習のため「製品Aの満足度はいかがですか？」を自動入力しました。',
     autoInput: { kind: 'text', value: '製品Aの満足度はいかがですか？' },
   },
   {
@@ -181,8 +183,8 @@ export const TUTORIAL_STEPS = [
     optionIndex: 0,
     mode: 'autofill',
     placement: 'right',
-    title: '選択肢1',
-    body: 'ここが選択肢1です。回答者が選べる選択肢の1つ目です。練習のため「とても満足」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '選択肢1を入力',
+    body: '回答者が選べる選択肢の1つ目です。練習のため「とても満足」を自動入力しました。',
     autoInput: { kind: 'text', value: 'とても満足' },
   },
   {
@@ -194,8 +196,8 @@ export const TUTORIAL_STEPS = [
     optionIndex: 1,
     mode: 'autofill',
     placement: 'right',
-    title: '選択肢2',
-    body: 'ここが選択肢2です。回答者が選べる選択肢の2つ目です。練習のため「満足」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '選択肢2を入力',
+    body: '回答者が選べる選択肢の2つ目です。練習のため「満足」を自動入力しました。',
     autoInput: { kind: 'text', value: '満足' },
   },
   {
@@ -207,8 +209,8 @@ export const TUTORIAL_STEPS = [
     optionIndex: 2,
     mode: 'autofill',
     placement: 'right',
-    title: '選択肢3',
-    body: 'ここが選択肢3です。回答者が選べる選択肢の3つ目です。練習のため「やや不満」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '選択肢3を入力',
+    body: '回答者が選べる選択肢の3つ目です。練習のため「やや不満」を自動入力しました。',
     autoInput: { kind: 'text', value: 'やや不満' },
   },
   {
@@ -220,8 +222,8 @@ export const TUTORIAL_STEPS = [
     optionIndex: 3,
     mode: 'autofill',
     placement: 'right',
-    title: '選択肢4',
-    body: 'ここが選択肢4です。回答者が選べる選択肢の4つ目です。練習のため「不満」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '選択肢4を入力',
+    body: '回答者が選べる選択肢の4つ目です。練習のため「不満」を自動入力しました。',
     autoInput: { kind: 'text', value: '不満' },
   },
 
@@ -255,8 +257,8 @@ export const TUTORIAL_STEPS = [
     fieldPath: 'questionText',
     mode: 'autofill',
     placement: 'right',
-    title: '評定尺度の設問文',
-    body: 'ここが設問文です。回答者に何を聞くかを書く欄です。練習のため「今回のサービス全体の満足度をお聞かせください。」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '設問文を入力',
+    body: '回答者に何を聞くかを書く欄です。練習のため「今回のサービス全体の満足度をお聞かせください。」を自動入力しました。',
     autoInput: { kind: 'text', value: '今回のサービス全体の満足度をお聞かせください。' },
   },
   {
@@ -267,8 +269,8 @@ export const TUTORIAL_STEPS = [
     fieldPath: 'minLabel',
     mode: 'autofill',
     placement: 'right',
-    title: '最小値ラベル（左端）',
-    body: 'ここが最小値ラベルです。評定尺度の左端（最低評価）に表示される文言です。練習のため「とても不満」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '最小値ラベルを入力',
+    body: '評定尺度の左端（最低評価）に表示される文言です。練習のため「とても不満」を自動入力しました。',
     autoInput: { kind: 'text', value: 'とても不満' },
   },
   {
@@ -279,51 +281,89 @@ export const TUTORIAL_STEPS = [
     fieldPath: 'maxLabel',
     mode: 'autofill',
     placement: 'right',
-    title: '最大値ラベル（右端）',
-    body: 'ここが最大値ラベルです。評定尺度の右端（最高評価）に表示される文言です。練習のため「とても満足」を自動入力しました。確認できたら「次へ」を押してください。',
+    title: '最大値ラベルを入力',
+    body: '評定尺度の右端（最高評価）に表示される文言です。練習のため「とても満足」を自動入力しました。',
     autoInput: { kind: 'text', value: 'とても満足' },
   },
 
+  // ------------------------------------------------------------
+  // ブロック D: プレビュー確認 〜 QR・保存・完了
+  // ------------------------------------------------------------
   {
     id: 23,
-    block: 'C',
-    target: '#createSurveyBtn',
-    mode: 'user-action-bridge',
+    block: 'D',
+    target: '#showPreviewBtn',
+    mode: 'user-action',
     placement: 'left',
-    title: 'アンケートを作成（練習・保存されません）',
-    body: '右側の「アンケートを作成」ボタンを押してください。これは練習のため、実際には保存されず、アンケート一覧にも追加されません。続けて QR コードの確認方法を見てみましょう。',
+    title: 'プレビューを開く',
+    body: '右側の「プレビュー」ボタンを押してください。回答者にどのように表示されるかを確認できます。',
   },
-
-  // ------------------------------------------------------------
-  // ブロック D: QR コード確認 〜 完了
-  // ------------------------------------------------------------
   {
     id: 24,
+    block: 'D',
+    target: '#v2-preview-tablet-btn',
+    waitForElement: true,
+    mode: 'user-action',
+    placement: 'bottom',
+    title: '表示サイズを切り替える',
+    body: '「タブレット」を押してみましょう。スマートフォン表示とタブレット表示で、回答画面の見え方の違いを確認できます。',
+  },
+  {
+    id: 25,
+    block: 'D',
+    target: '#v2-preview-device-frame',
+    waitForElement: true,
+    mode: 'info',
+    placement: 'left',
+    title: '回答とサンクス画面を確認',
+    body: 'プレビュー内のアンケートに回答し、最後に「送信」を押してみましょう。回答者に表示される「サンクス画面」まで確認できます。確認できたら「次へ」を押してください。',
+  },
+  {
+    id: 26,
+    block: 'D',
+    target: '#surveyPreviewModalV2 button.bg-secondary-container',
+    waitForElement: true,
+    mode: 'user-action',
+    placement: 'top',
+    title: 'プレビューを閉じる',
+    body: '確認できたら「閉じる」を押してプレビューを閉じます。',
+  },
+  {
+    id: 27,
     block: 'D',
     target: '#openQrModalBtn',
     mode: 'user-action',
     placement: 'left',
     title: 'QR コードを表示',
-    body: '「QR コード」ボタンを押して QR コードを表示してみましょう。',
+    body: '「QR 発行」ボタンを押して QR コードを表示してみましょう。',
   },
   {
-    id: 25,
+    id: 28,
     block: 'D',
-    target: '#qrCodeModal .modal-content-transition',
-    mode: 'info',
-    placement: 'left',
-    title: 'QR コードの使い方',
-    body: 'この QR コードを展示会で配布したり画面に表示することで、来場者がアンケートに回答できます。',
+    target: '#footerCloseQrCodeModalBtn',
     waitForElement: true,
+    mode: 'user-action',
+    placement: 'top',
+    title: 'QR コードの使い方を確認',
+    body: 'アンケートを保存すると、ここに回答用の QR コードが発行されます。展示会で配布したり画面に表示することで、来場者がアンケートに回答できます。確認できたら「閉じる」を押してください。',
   },
   {
-    id: 26,
+    id: 29,
+    block: 'D',
+    target: '#createSurveyBtn',
+    mode: 'user-action-bridge',
+    placement: 'left',
+    title: 'アンケートを保存する',
+    body: '右側の「アンケートを保存する」ボタンを押してください。保存してもこの画面のまま、ダッシュボードへ自動では移動しません。（練習のため実際には保存されません）',
+  },
+  {
+    id: 30,
     block: 'D',
     target: null,
     mode: 'user-action-bridge',
     placement: 'center',
     title: 'チュートリアル完了',
-    body: 'お疲れさまでした。「完了」を押してダッシュボードへ戻ります。',
+    body: 'お疲れさまでした。これでアンケート作成の基本フローは完了です。「完了」を押すとアンケート一覧へ移動します。',
     completeButtonLabel: '完了',
   },
 ];

--- a/05_support/tutorial/src/tutorial/tutorial.css
+++ b/05_support/tutorial/src/tutorial/tutorial.css
@@ -1,32 +1,41 @@
 /* tutorial.css
- * SPEED AD チュートリアル UI（仕様書 §8）
- *   - グラスモーフィズム + ホログラフィック方向
- *   - マスク + スポットライト枠（二重リング & パルス）
- *   - コーチマーク（グラス枠 + グラデボーダー）
- *   - 発光ドット型ポインタ（同心円パルス）
+ * SPEED AD チュートリアル UI
+ *   - サービス本体の配色（白基調 + Google Blue #4285F4 のフラットな Material デザイン）に準拠
+ *   - service-top-style.css の CSS カスタムプロパティ（--color-*）を var() 参照し、
+ *     サービスがダークモード（body.dark-mode）のときは自動追従する
+ *   - マスク + スポットライト枠（青リング & パルス）
+ *   - コーチマーク（カード + 青枠）
+ *   - 青ドット型ポインタ（同心円パルス）
  *   - 進行バー + 練習モードバッジ
  *   - スキップ確認モーダル
  */
 
 :root {
-  /* ----- ホログラフィック / グラスモーフィズム パレット ----- */
-  --tut-bg-deep: #0B1220;
-  --tut-glass: rgba(15, 23, 42, 0.78);
-  --tut-glass-light: rgba(15, 23, 42, 0.72);
-  --tut-stroke-cyan: #22D3EE;
-  --tut-stroke-violet: #A78BFA;
-  --tut-accent-cyan: #22D3EE;
-  --tut-accent-cyan-glow: rgba(34, 211, 238, 0.55);
-  --tut-accent-violet: #A78BFA;
-  --tut-accent-violet-glow: rgba(167, 139, 250, 0.55);
-  --tut-text: rgba(255, 255, 255, 0.95);
-  --tut-text-sub: rgba(203, 213, 225, 0.75);
+  /* ----- サービス配色準拠パレット -----
+     service-top-style.css の --color-* トークンを参照。
+     サービス未読込環境でも破綻しないようフォールバック値を併記する。 */
+  --tut-bg-deep: var(--color-base-background-main, #FFFFFF);
+  --tut-glass: var(--color-base-card, #FFFFFF);
+  --tut-glass-light: var(--color-base-card, #FFFFFF);
+  --tut-surface-sub: var(--color-base-background-sub, #F8F8F8);
+  --tut-border: var(--color-base-border-divider, #E0E0E0);
+  --tut-stroke-cyan: var(--color-brand-base-primary, #4285F4);
+  --tut-stroke-violet: var(--color-button-primary-hover-bg, #3367D6);
+  --tut-accent-cyan: var(--color-brand-base-primary, #4285F4);
+  --tut-accent-cyan-glow: rgba(66, 133, 244, 0.30);
+  --tut-accent-violet: var(--color-button-primary-hover-bg, #3367D6);
+  --tut-accent-violet-glow: rgba(51, 103, 214, 0.22);
+  --tut-on-accent: var(--color-button-primary-text, #FFFFFF);
+  --tut-text: var(--color-text-main, #1A1A1A);
+  --tut-text-sub: var(--color-text-sub, #6B6B6B);
+  --tut-scrim: var(--color-scrim, rgba(0, 0, 0, 0.15));
+  --tut-shadow-soft: var(--color-base-shadow-soft, 0 1px 2px 0 rgba(0, 0, 0, 0.05));
   --tut-mono: 'JetBrains Mono', 'Inter', ui-monospace, 'SF Mono', Menlo, monospace;
 
   /* ----- 後方互換用エイリアス ----- */
   --tutorial-primary: var(--tut-accent-cyan);
   --tutorial-primary-glow: var(--tut-accent-cyan-glow);
-  --tutorial-mask-color: rgba(11, 18, 32, 0.6);
+  --tutorial-mask-color: var(--tut-scrim);
   --tutorial-bubble-bg: var(--tut-glass);
   --tutorial-bubble-text: var(--tut-text);
   --tutorial-bubble-subtext: var(--tut-text-sub);
@@ -41,6 +50,21 @@
   font-family: inherit;
 }
 
+/* ----- スクリーンリーダー専用（視覚的に隠す）-----
+   overlay.js の aria-live 領域がこのクラスを使用する。 */
+.tutorial-sr-only {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ============================================================
    マスク
    ============================================================ */
@@ -49,42 +73,40 @@
   inset: 0;
   pointer-events: none; /* SVG 自体はクリック透過。対象外クリックは overlay.js の window レベル capture で判定 */
   z-index: 9020;
+  /* サービスのモーダル scrim 準拠の無彩色。ごく薄い青みのみ残す */
   background:
-    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(34, 211, 238, 0.05), transparent 70%),
-    radial-gradient(ellipse 60% 50% at 100% 100%, rgba(167, 139, 250, 0.06), transparent 70%);
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(66, 133, 244, 0.04), transparent 70%),
+    radial-gradient(ellipse 60% 50% at 100% 100%, rgba(66, 133, 244, 0.03), transparent 70%);
 }
 
 /* ============================================================
-   スポットライト枠（二重リング + パルス）
+   スポットライト枠（青リング + パルス）
    ============================================================ */
 .tutorial-spotlight {
   position: fixed;
   pointer-events: none;
   z-index: 9030;
-  border: 1px solid var(--tut-accent-cyan);
+  border: 2px solid var(--tut-accent-cyan);
   border-radius: 8px;
   box-shadow:
-    0 0 0 1px rgba(34, 211, 238, 0.45),
+    0 0 0 1px rgba(66, 133, 244, 0.35),
     0 0 4px 1px var(--tut-accent-cyan-glow),
-    0 0 8px 2px rgba(34, 211, 238, 0.35),
-    0 0 12px 4px var(--tut-accent-violet-glow);
+    0 0 8px 2px rgba(66, 133, 244, 0.22);
   animation: tutorial-spotlight-pulse 1.6s ease-in-out infinite;
 }
 
 @keyframes tutorial-spotlight-pulse {
   0%, 100% {
     box-shadow:
-      0 0 0 1px rgba(34, 211, 238, 0.45),
+      0 0 0 1px rgba(66, 133, 244, 0.35),
       0 0 4px 1px var(--tut-accent-cyan-glow),
-      0 0 6px 2px rgba(34, 211, 238, 0.3),
-      0 0 8px 3px var(--tut-accent-violet-glow);
+      0 0 6px 2px rgba(66, 133, 244, 0.18);
   }
   50% {
     box-shadow:
-      0 0 0 1px rgba(34, 211, 238, 0.75),
+      0 0 0 1px rgba(66, 133, 244, 0.55),
       0 0 8px 3px var(--tut-accent-cyan-glow),
-      0 0 12px 5px rgba(34, 211, 238, 0.5),
-      0 0 16px 6px var(--tut-accent-violet-glow);
+      0 0 12px 5px rgba(66, 133, 244, 0.32);
   }
 }
 
@@ -104,52 +126,29 @@
   }
   50% {
     transform: scale(1.03);
-    filter: brightness(1.25);
+    filter: brightness(1.08);
   }
 }
 
 /* ============================================================
-   コーチマーク（グラス + グラデボーダー）
+   コーチマーク（白カード + 青枠）
    ============================================================ */
 .tutorial-coachmark {
   position: fixed;
   width: 400px;
   padding: 24px;
-  border-radius: 16px;
+  border-radius: 12px;
   background: var(--tut-glass);
-  -webkit-backdrop-filter: blur(20px) saturate(150%);
-  backdrop-filter: blur(20px) saturate(150%);
   color: var(--tut-text);
   z-index: 9050;
   pointer-events: auto;
   font-size: 15px;
   line-height: 1.7;
+  border: 1px solid var(--tut-border);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-  /* グラデーション枠を border-image で実現 */
-  border: 1px solid transparent;
-  background-clip: padding-box;
+    0 8px 24px rgba(0, 0, 0, 0.16),
+    0 0 0 1px rgba(66, 133, 244, 0.10);
   animation: tutorial-coachmark-in 240ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-/* border-image で角丸が落ちる環境向けに擬似要素でグラデ枠を重ねる */
-.tutorial-coachmark::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(135deg, var(--tut-stroke-cyan), var(--tut-stroke-violet));
-  -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-          mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-          mask-composite: exclude;
-  pointer-events: none;
 }
 
 @keyframes tutorial-coachmark-in {
@@ -165,8 +164,12 @@
 
 @media (max-width: 768px) {
   .tutorial-coachmark {
-    width: calc(100vw - 32px);
-    max-width: calc(100vw - 32px);
+    /* モバイルでは中央寄せの固定幅に収め、画面端からのはみ出しを防ぐ */
+    width: calc(100vw - 24px);
+    max-width: calc(100vw - 24px);
+    left: 12px !important;
+    right: 12px !important;
+    padding: 18px;
   }
 }
 
@@ -176,24 +179,6 @@
   gap: 12px;
   align-items: center;
   margin-bottom: 12px;
-}
-
-.tutorial-coachmark__step-badge {
-  display: inline-flex;
-  align-items: center;
-  font-family: var(--tut-mono);
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--tut-accent-cyan);
-  background: transparent;
-  border: 1px solid var(--tut-accent-cyan);
-  padding: 2px 8px;
-  border-radius: 4px;
-  letter-spacing: 0.08em;
-  line-height: 1.4;
-  white-space: nowrap;
-  -webkit-user-select: none;
-  user-select: none;
 }
 
 .tutorial-coachmark__title {
@@ -215,6 +200,7 @@
 /* ----- フッター ----- */
 .tutorial-coachmark__footer {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   margin-top: 20px;
@@ -233,6 +219,7 @@
   cursor: pointer;
   padding: 4px 0;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .tutorial-coachmark__skip:hover {
@@ -241,45 +228,46 @@
 }
 
 .tutorial-coachmark__prev {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: var(--tut-surface-sub);
+  border: 1px solid var(--tut-border);
   color: var(--tut-text);
   font-size: 14px;
   padding: 6px 14px;
   border-radius: 8px;
   cursor: pointer;
+  white-space: nowrap;
   transition: background-color 160ms ease, border-color 160ms ease;
 }
 
 .tutorial-coachmark__prev:hover {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.28);
+  background: var(--tut-border);
+  border-color: var(--tut-border);
 }
 
 .tutorial-coachmark__next {
-  background: linear-gradient(135deg, var(--tut-accent-cyan), var(--tut-accent-violet));
+  background: var(--tut-accent-cyan);
   border: none;
-  color: #0B1220;
+  color: var(--tut-on-accent);
   font-size: 14px;
   font-weight: 600;
   padding: 6px 16px;
   border-radius: 8px;
   cursor: pointer;
-  box-shadow: 0 0 12px rgba(34, 211, 238, 0.35);
-  transition: box-shadow 200ms ease, transform 160ms ease;
+  white-space: nowrap;
+  transition: background-color 200ms ease, transform 160ms ease;
 }
 
 .tutorial-coachmark__next:hover {
-  box-shadow:
-    0 0 16px rgba(34, 211, 238, 0.6),
-    0 0 24px rgba(167, 139, 250, 0.45);
+  background: var(--tut-accent-violet);
 }
 
 .tutorial-coachmark__hint {
+  flex-basis: 100%;
   font-size: 13px;
   color: var(--tut-accent-cyan);
   font-family: var(--tut-mono);
-  margin-left: 8px;
+  margin-left: 0;
+  text-align: right;
 }
 
 /* G4: 6秒間クリック検出が無いときに表示する救済ヒント。
@@ -294,7 +282,7 @@
 }
 
 /* ============================================================
-   コネクタ（発光細線）
+   コネクタ（細線）
    - 新規: .tutorial-coachmark__connector
    - 後方互換: .tutorial-coachmark__notch（同スタイルを適用）
    ============================================================ */
@@ -302,7 +290,6 @@
 .tutorial-coachmark__notch {
   position: absolute;
   background: var(--tut-accent-cyan);
-  box-shadow: 0 0 8px var(--tut-accent-cyan-glow);
   pointer-events: none;
   /* デフォルトでは旧三角形の border ハックを無効化 */
   border: none;
@@ -316,7 +303,7 @@
   bottom: -24px;
   left: 50%;
   transform: translateX(-50%);
-  width: 1px;
+  width: 2px;
   height: 24px;
 }
 
@@ -326,7 +313,7 @@
   top: -24px;
   left: 50%;
   transform: translateX(-50%);
-  width: 1px;
+  width: 2px;
   height: 24px;
 }
 
@@ -337,7 +324,7 @@
   top: 50%;
   transform: translateY(-50%);
   width: 24px;
-  height: 1px;
+  height: 2px;
 }
 
 /* right: コーチマーク左端から左に伸びる横線 */
@@ -347,11 +334,43 @@
   top: 50%;
   transform: translateY(-50%);
   width: 24px;
-  height: 1px;
+  height: 2px;
+}
+
+/* モバイルではコネクタを短くして画面外への突き出しを抑える */
+@media (max-width: 768px) {
+  .tutorial-coachmark__connector[data-placement="top"],
+  .tutorial-coachmark__notch[data-placement="top"],
+  .tutorial-coachmark__connector[data-placement="bottom"],
+  .tutorial-coachmark__notch[data-placement="bottom"] {
+    height: 16px;
+  }
+  .tutorial-coachmark__connector[data-placement="top"],
+  .tutorial-coachmark__notch[data-placement="top"] {
+    bottom: -16px;
+  }
+  .tutorial-coachmark__connector[data-placement="bottom"],
+  .tutorial-coachmark__notch[data-placement="bottom"] {
+    top: -16px;
+  }
+  .tutorial-coachmark__connector[data-placement="left"],
+  .tutorial-coachmark__notch[data-placement="left"],
+  .tutorial-coachmark__connector[data-placement="right"],
+  .tutorial-coachmark__notch[data-placement="right"] {
+    width: 16px;
+  }
+  .tutorial-coachmark__connector[data-placement="left"],
+  .tutorial-coachmark__notch[data-placement="left"] {
+    right: -16px;
+  }
+  .tutorial-coachmark__connector[data-placement="right"],
+  .tutorial-coachmark__notch[data-placement="right"] {
+    left: -16px;
+  }
 }
 
 /* ============================================================
-   ポインタ（発光ドット + 同心円パルス 3層）
+   ポインタ（青ドット + 同心円パルス 3層）
    ============================================================ */
 .tutorial-pointer {
   position: fixed;
@@ -365,7 +384,7 @@
   justify-content: center;
 }
 
-/* 中央の発光ドット */
+/* 中央の青ドット */
 .tutorial-pointer::after {
   content: "";
   position: absolute;
@@ -374,7 +393,7 @@
   border-radius: 50%;
   background: var(--tut-accent-cyan);
   box-shadow:
-    0 0 16px var(--tut-accent-cyan-glow),
+    0 0 12px var(--tut-accent-cyan-glow),
     0 0 4px rgba(255, 255, 255, 0.8) inset;
   z-index: 2;
 }
@@ -389,7 +408,7 @@
   margin-top: -12px;
   margin-left: -12px;
   border-radius: 50%;
-  border: 1px solid var(--tut-accent-cyan);
+  border: 2px solid var(--tut-accent-cyan);
   background: transparent;
   opacity: 0;
   animation: tutorial-pointer-ring 1.4s ease-out infinite;
@@ -410,7 +429,7 @@
 @keyframes tutorial-pointer-ring {
   0% {
     transform: scale(1);
-    opacity: 0.75;
+    opacity: 0.7;
   }
   100% {
     transform: scale(2.6);
@@ -432,9 +451,7 @@
   left: 0;
   right: 0;
   height: 48px;
-  background: var(--tut-glass-light);
-  -webkit-backdrop-filter: blur(16px) saturate(140%);
-  backdrop-filter: blur(16px) saturate(140%);
+  background: var(--tut-glass);
   color: var(--tut-text);
   display: flex;
   align-items: center;
@@ -442,10 +459,8 @@
   padding: 0 20px;
   z-index: 9100;
   pointer-events: auto;
-  /* 下端のグラデボーダー */
-  border-bottom: 1px solid transparent;
-  background-clip: padding-box;
-  box-shadow: 0 1px 0 0 transparent;
+  border-bottom: 1px solid var(--tut-border);
+  box-shadow: var(--tut-shadow-soft);
 }
 
 .tutorial-progressbar::after {
@@ -454,8 +469,8 @@
   left: 0;
   right: 0;
   bottom: -1px;
-  height: 1px;
-  background: linear-gradient(90deg, var(--tut-stroke-cyan), var(--tut-stroke-violet));
+  height: 2px;
+  background: var(--tut-accent-cyan);
   pointer-events: none;
 }
 
@@ -463,8 +478,8 @@
   font-family: var(--tut-mono);
   font-size: 11px;
   font-weight: 600;
-  color: var(--tut-accent-cyan);
-  background: transparent;
+  color: var(--tut-on-accent);
+  background: var(--tut-accent-cyan);
   border: 1px solid var(--tut-accent-cyan);
   padding: 3px 10px;
   border-radius: 4px;
@@ -494,10 +509,28 @@
   white-space: nowrap;
 }
 
+/* モバイルでは note を折り返し可にし、「保存されません」が省略で消えないようにする */
+@media (max-width: 768px) {
+  .tutorial-progressbar {
+    height: auto;
+    min-height: 48px;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    padding: 8px 16px;
+  }
+  .tutorial-progressbar__note {
+    flex-basis: 100%;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    line-height: 1.4;
+  }
+}
+
 .tutorial-progressbar__bar {
   width: 220px;
   height: 4px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tut-surface-sub);
   border-radius: 999px;
   overflow: hidden;
 }
@@ -505,10 +538,7 @@
 .tutorial-progressbar__fill {
   height: 100%;
   width: 0%;
-  background: linear-gradient(90deg, var(--tut-accent-cyan), var(--tut-accent-violet));
-  box-shadow:
-    0 0 8px var(--tut-accent-cyan-glow),
-    0 0 12px var(--tut-accent-violet-glow);
+  background: var(--tut-accent-cyan);
   border-radius: inherit;
   transition: width 220ms ease-out;
 }
@@ -519,9 +549,7 @@
 .tutorial-skip-modal {
   position: fixed;
   inset: 0;
-  background: rgba(11, 18, 32, 0.6);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  background: var(--tut-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -532,36 +560,15 @@
 .tutorial-skip-modal__panel {
   position: relative;
   background: var(--tut-glass);
-  -webkit-backdrop-filter: blur(20px) saturate(150%);
-  backdrop-filter: blur(20px) saturate(150%);
   color: var(--tut-text);
   width: min(420px, calc(100vw - 32px));
   padding: 24px;
-  border-radius: 16px;
-  border: 1px solid transparent;
-  background-clip: padding-box;
+  border-radius: 12px;
+  border: 1px solid var(--tut-border);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.45),
-    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    0 8px 32px rgba(0, 0, 0, 0.22),
+    0 0 0 1px rgba(66, 133, 244, 0.10);
   animation: tutorial-coachmark-in 240ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.tutorial-skip-modal__panel::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(135deg, var(--tut-stroke-cyan), var(--tut-stroke-violet));
-  -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-          mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-          mask-composite: exclude;
-  pointer-events: none;
 }
 
 .tutorial-skip-modal__title {
@@ -585,9 +592,27 @@
   gap: 8px;
 }
 
+/* 「終了する」(.confirm) を控えめスタイルに、
+   「続ける」(.cancel) をプライマリ強調スタイルに入れ替え。 */
 .tutorial-skip-modal__cancel {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: var(--tut-accent-cyan);
+  border: none;
+  color: var(--tut-on-accent);
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 200ms ease;
+}
+
+.tutorial-skip-modal__cancel:hover {
+  background: var(--tut-accent-violet);
+}
+
+.tutorial-skip-modal__confirm {
+  background: var(--tut-surface-sub);
+  border: 1px solid var(--tut-border);
   color: var(--tut-text);
   padding: 8px 16px;
   border-radius: 8px;
@@ -596,28 +621,9 @@
   transition: background-color 160ms ease, border-color 160ms ease;
 }
 
-.tutorial-skip-modal__cancel:hover {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.28);
-}
-
-.tutorial-skip-modal__confirm {
-  background: linear-gradient(135deg, var(--tut-accent-cyan), var(--tut-accent-violet));
-  border: none;
-  color: #0B1220;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 0 12px rgba(34, 211, 238, 0.35);
-  transition: box-shadow 200ms ease;
-}
-
 .tutorial-skip-modal__confirm:hover {
-  box-shadow:
-    0 0 16px rgba(34, 211, 238, 0.6),
-    0 0 24px rgba(167, 139, 250, 0.45);
+  background: var(--tut-border);
+  border-color: var(--tut-border);
 }
 
 /* ============================================================
@@ -632,12 +638,10 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
+  /* 無彩色スクリム + ごく薄い青みのみ */
   background:
-    radial-gradient(ellipse 70% 50% at 50% 35%, rgba(34, 211, 238, 0.12), transparent 70%),
-    radial-gradient(ellipse 60% 50% at 50% 100%, rgba(167, 139, 250, 0.10), transparent 70%),
-    rgba(11, 18, 32, 0.85);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
+    radial-gradient(ellipse 70% 50% at 50% 35%, rgba(66, 133, 244, 0.06), transparent 70%),
+    var(--tut-scrim);
   animation: tutorial-welcome-fade 280ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -650,37 +654,15 @@
   position: relative;
   width: min(520px, 100%);
   padding: 48px 40px;
-  border-radius: 20px;
+  border-radius: 16px;
   background: var(--tut-glass);
-  -webkit-backdrop-filter: blur(24px) saturate(160%);
-  backdrop-filter: blur(24px) saturate(160%);
   color: var(--tut-text);
   text-align: center;
-  border: 1px solid transparent;
-  background-clip: padding-box;
+  border: 1px solid var(--tut-border);
   box-shadow:
-    0 24px 64px rgba(0, 0, 0, 0.5),
-    0 0 48px rgba(34, 211, 238, 0.15),
-    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    0 24px 48px rgba(0, 0, 0, 0.24),
+    0 0 0 1px rgba(66, 133, 244, 0.10);
   animation: tutorial-welcome-panel-in 360ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.tutorial-welcome__panel::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(135deg, var(--tut-stroke-cyan), var(--tut-stroke-violet));
-  -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-          mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-          mask-composite: exclude;
-  pointer-events: none;
 }
 
 @keyframes tutorial-welcome-panel-in {
@@ -709,11 +691,7 @@
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1.2;
-  background: linear-gradient(135deg, #FFFFFF, var(--tut-accent-cyan));
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
+  color: var(--tut-text);
 }
 
 .tutorial-welcome__body {
@@ -747,25 +725,159 @@
 }
 
 .tutorial-welcome__start {
-  background: linear-gradient(135deg, var(--tut-accent-cyan), var(--tut-accent-violet));
+  background: var(--tut-accent-cyan);
   border: none;
-  color: #0B1220;
+  color: var(--tut-on-accent);
   font-size: 16px;
   font-weight: 600;
   padding: 12px 32px;
   border-radius: 10px;
   cursor: pointer;
   letter-spacing: 0.02em;
-  box-shadow:
-    0 4px 16px rgba(34, 211, 238, 0.4),
-    0 0 0 1px rgba(255, 255, 255, 0.1) inset;
-  transition: box-shadow 200ms ease, transform 160ms ease;
+  box-shadow: 0 4px 12px rgba(66, 133, 244, 0.28);
+  transition: background-color 200ms ease, box-shadow 200ms ease, transform 160ms ease;
 }
 
 .tutorial-welcome__start:hover {
-  box-shadow:
-    0 6px 24px rgba(34, 211, 238, 0.6),
-    0 0 32px rgba(167, 139, 250, 0.45),
-    0 0 0 1px rgba(255, 255, 255, 0.18) inset;
+  background: var(--tut-accent-violet);
+  box-shadow: 0 6px 18px rgba(66, 133, 244, 0.36);
   transform: translateY(-1px);
+}
+
+/* ============================================================
+   アカウント作成 CTA 画面（チュートリアル完了 / スキップ後）
+   - ようこそ画面（.tutorial-welcome）と同系統の見た目で構成
+   ============================================================ */
+.tutorial-account-cta {
+  position: fixed;
+  inset: 0;
+  z-index: 9300;
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  /* 無彩色スクリム + ごく薄い青みのみ */
+  background:
+    radial-gradient(ellipse 70% 50% at 50% 35%, rgba(66, 133, 244, 0.06), transparent 70%),
+    var(--tut-scrim);
+  animation: tutorial-welcome-fade 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tutorial-account-cta__panel {
+  position: relative;
+  width: min(520px, 100%);
+  padding: 48px 40px;
+  border-radius: 16px;
+  background: var(--tut-glass);
+  color: var(--tut-text);
+  text-align: center;
+  border: 1px solid var(--tut-border);
+  box-shadow:
+    0 24px 48px rgba(0, 0, 0, 0.24),
+    0 0 0 1px rgba(66, 133, 244, 0.10);
+  animation: tutorial-welcome-panel-in 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tutorial-account-cta__eyebrow {
+  font-family: var(--tut-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  color: var(--tut-accent-cyan);
+  margin-bottom: 16px;
+}
+
+.tutorial-account-cta__title {
+  margin: 0 0 20px;
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--tut-text);
+}
+
+.tutorial-account-cta__body {
+  margin: 0 0 32px;
+  font-size: 15px;
+  line-height: 1.8;
+  color: var(--tut-text-sub);
+}
+
+.tutorial-account-cta__actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.tutorial-account-cta__close {
+  background: transparent;
+  border: none;
+  color: var(--tut-text-sub);
+  font-size: 14px;
+  padding: 10px 16px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color 160ms ease;
+}
+
+.tutorial-account-cta__close:hover {
+  color: var(--tut-text);
+  text-decoration: underline;
+}
+
+.tutorial-account-cta__create {
+  background: var(--tut-accent-cyan);
+  border: none;
+  color: var(--tut-on-accent);
+  font-size: 16px;
+  font-weight: 600;
+  padding: 12px 32px;
+  border-radius: 10px;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  box-shadow: 0 4px 12px rgba(66, 133, 244, 0.28);
+  transition: background-color 200ms ease, box-shadow 200ms ease, transform 160ms ease;
+}
+
+.tutorial-account-cta__create:hover {
+  background: var(--tut-accent-violet);
+  box-shadow: 0 6px 18px rgba(66, 133, 244, 0.36);
+  transform: translateY(-1px);
+}
+
+/* ============================================================
+   prefers-reduced-motion: アニメーションを抑制
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .tutorial-spotlight,
+  .tutorial-spotlight.is-attention-pulse,
+  .tutorial-coachmark,
+  .tutorial-coachmark.is-attention-pulse,
+  .tutorial-pointer__ring,
+  .tutorial-skip-modal__panel,
+  .tutorial-welcome,
+  .tutorial-welcome__panel,
+  .tutorial-account-cta,
+  .tutorial-account-cta__panel {
+    animation: none !important;
+  }
+
+  .tutorial-coachmark__next,
+  .tutorial-coachmark__prev,
+  .tutorial-skip-modal__cancel,
+  .tutorial-skip-modal__confirm,
+  .tutorial-welcome__start,
+  .tutorial-welcome__skip,
+  .tutorial-account-cta__create,
+  .tutorial-account-cta__close,
+  .tutorial-progressbar__fill {
+    transition: none !important;
+  }
+
+  /* パルスリングは静止表示にせず非表示にする（残像防止） */
+  .tutorial-pointer__ring {
+    opacity: 0 !important;
+  }
 }

--- a/05_support/tutorial/survey-answer.html
+++ b/05_support/tutorial/survey-answer.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SpeedAd - アンケート回答</title>
+    <link rel="icon" href="assets/svg/speedad_logo.svg" type="image/svg+xml">
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="service-top-style.css">
+    <link rel="stylesheet" href="src/toolbox.css">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+    <link as="style" href="https://fonts.googleapis.com/css2?display=swap&family=Inter%3Awght%40400%3B500%3B700%3B900&family=Noto+Sans+JP%3Awght%40400%3B500%3B700%3B900" onload="this.rel='stylesheet'" rel="stylesheet">
+    <style>
+        /* --- Layout Fixes & Overrides --- */
+        body {
+            padding-left: 0 !important;
+        }
+        .survey-content-wrapper {
+            max-width: 768px; /* max-w-3xl */
+            margin-left: auto;
+            margin-right: auto;
+            padding-left: 1rem;
+            padding-right: 1rem;
+            width: 100%;
+        }
+
+        /* --- Custom Component Styles --- */
+        .survey-question-card {
+            background-color: #fff;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+            margin-bottom: 1.5rem;
+            transition: all 0.2s ease-in-out;
+        }
+
+        .survey-question-card.is-required {
+            border-left: 4px solid transparent;
+        }
+        .survey-question-card .question-content {
+            padding: 1.5rem;
+        }
+
+        /* --- Header Scroll Behavior --- */
+        .header-unpinned {
+            transform: translateY(-100%);
+            transition: transform 0.3s ease-in-out;
+        }
+
+        /* --- 名刺プレビュー --- */
+        .bizcard-preview-img {
+            width: 100%;
+            height: auto;
+            max-height: 160px;
+            object-fit: contain;
+            background-color: #f3f4f6;
+            border-radius: 6px;
+        }
+        .bizcard-preview-back-empty {
+            height: 160px;
+        }
+        .bizcard-preview-back-actions-hidden {
+            display: none !important;
+        }
+        #submitting-progress-bar {
+            width: 0%;
+        }
+    </style>
+</head>
+<body class="bg-gray-50">
+
+    <div id="survey-main-wrapper" style="background-color: #E0F2F7;" class="text-gray-800 min-h-screen">
+        <!-- ローディングインジケーター -->
+        <div id="loading-indicator" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-blue-500"></div>
+        </div>
+
+
+
+
+        <!-- メインコンテンツ -->
+        <main id="main-content" class="py-2">
+            <div class="survey-content-wrapper">
+                        <!-- Language Switcher -->
+                <div id="language-switcher-container" class="relative flex justify-end items-center mb-4">
+                    <select id="language-select" class="w-40 block pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100 focus:border-indigo-500 sm:text-sm rounded-md">
+                        <!-- Language options will be dynamically inserted here by JS -->
+                    </select>
+                </div>                <div id="survey-title-container" class="mb-6"></div>
+                <div id="error-container" class="hidden bg-red-100 text-red-700 p-4 rounded-lg mb-6" role="alert">
+                    <!-- エラーメッセージ表示領域 -->
+                </div>
+                <form id="survey-form" class="space-y-6"></form>
+
+                <!-- 名刺プレビューエリア（撮影後に表示） -->
+                <div id="bizcard-preview-area" class="hidden w-full bg-white border border-gray-200 rounded-lg shadow-sm p-4 mb-4 mt-6">
+                    <p class="text-sm font-medium text-gray-600 mb-3">撮影済み名刺</p>
+                    <div class="flex gap-4">
+                        <div class="flex-1">
+                            <p class="text-xs text-center text-gray-500 mb-2">表面</p>
+                            <div id="bizcard-preview-front-container" class="relative group">
+                                <img id="bizcard-preview-front" src="" alt="名刺 表面" class="bizcard-preview-img w-full rounded-md shadow-sm cursor-pointer">
+                                <div class="absolute inset-0 hidden group-hover:flex items-center justify-center gap-2 bg-black bg-opacity-40 rounded-md">
+                                    <button id="bizcard-retake-front" type="button" class="px-2 py-1 text-xs font-bold text-white bg-blue-600 rounded hover:bg-blue-700">再撮影</button>
+                                    <button id="bizcard-delete-front" type="button" class="px-2 py-1 text-xs font-bold text-white bg-red-600 rounded hover:bg-red-700">削除</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="flex-1" id="bizcard-preview-back-wrapper">
+                            <p class="text-xs text-center text-gray-500 mb-2">裏面</p>
+                            <div id="bizcard-preview-back-container" class="relative group">
+                                <img id="bizcard-preview-back" src="" alt="名刺 裏面" class="bizcard-preview-img w-full rounded-md shadow-sm cursor-pointer hidden">
+                                <div id="bizcard-preview-back-empty" class="bizcard-preview-back-empty w-full flex items-center justify-center bg-gray-100 border border-dashed border-gray-300 rounded-md text-xs text-gray-400 cursor-pointer hover:bg-gray-200">
+                                    裏面を追加
+                                </div>
+                                <div class="absolute inset-0 hidden group-hover:flex items-center justify-center gap-2 bg-black bg-opacity-40 rounded-md bizcard-preview-back-actions-hidden" id="bizcard-preview-back-actions">
+                                    <button id="bizcard-retake-back" type="button" class="px-2 py-1 text-xs font-bold text-white bg-blue-600 rounded hover:bg-blue-700">再撮影</button>
+                                    <button id="bizcard-delete-back" type="button" class="px-2 py-1 text-xs font-bold text-white bg-red-600 rounded hover:bg-red-700">削除</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <!-- フッター -->
+        <footer class="bg-white shadow-md py-6">
+            <div class="survey-content-wrapper flex flex-col items-center gap-4">
+                <div class="w-full grid grid-cols-2 gap-4">
+                    <button id="bizcard-camera-button" type="button" class="w-full justify-center flex items-center gap-2 px-4 py-2 border rounded-full text-sm font-medium bg-blue-100 text-blue-800 hover:bg-blue-200 whitespace-nowrap">
+                        <span class="material-icons">photo_camera</span>
+                        <span>名刺を撮影</span>
+                    </button>
+                    <button id="submit-survey-button" type="button" class="w-full justify-center flex items-center px-6 py-2 bg-blue-600 text-white rounded-full text-sm font-bold shadow-sm hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap">
+                        送信する
+                    </button>
+                </div>
+                <div>
+                    <button id="bizcard-manual-button" type="button" class="text-sm font-medium text-blue-600 hover:underline whitespace-nowrap">名刺が手元に無い方</button>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <!-- Modals & Other Overlays -->
+    <div id="submitting-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50">
+        <div class="bg-white rounded-lg shadow-xl p-8 w-full max-w-sm text-center">
+            <p id="submitting-text" class="text-lg font-semibold mb-4">送信中...</p>
+            <div class="w-full bg-gray-200 rounded-full h-4">
+                <div id="submitting-progress-bar" class="bg-blue-600 h-4 rounded-full transition-all duration-300 ease-out"></div>
+            </div>
+            <p id="submitting-percentage" class="text-sm text-gray-600 mt-2">0%</p>
+        </div>
+    </div>
+    <div id="bizcard-upload-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50"></div>
+    <div id="manual-input-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50"></div>
+    <div id="leave-confirm-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50"></div>
+    <div id="draft-restore-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50"></div>
+    <div id="image-magnify-modal" class="fixed inset-0 bg-black bg-opacity-75 hidden items-center justify-center z-[60]"></div>
+            <div id="toast-notification" class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-gray-800 text-white py-2 px-4 rounded-lg shadow-lg hidden transform transition-all duration-300 ease-in-out">
+                <p id="toast-message" class="whitespace-nowrap overflow-hidden text-ellipsis"></p>
+            </div>
+        
+            <script type="module" src="src/survey-answer.js"></script></body>
+</html>

--- a/05_support/tutorial/surveyCreation.html
+++ b/05_support/tutorial/surveyCreation.html
@@ -620,7 +620,7 @@
                         <span class="material-icons text-[20px]">add_circle_outline</span> 最初の設問を追加
                       </button>
                     </div>
-                    <div id="inlineQuestionTypeMenu" class="hidden mt-6 grid grid-cols-2 gap-2 animate-fade-in-up">
+                    <div id="inlineQuestionTypeMenu" class="hidden mt-6 grid-cols-2 gap-2 animate-fade-in-up">
                       <!-- Populated by JS -->
                     </div>
                   </div>

--- a/docs/リライト版仕様書/user/31_tutorial_requirements.md
+++ b/docs/リライト版仕様書/user/31_tutorial_requirements.md
@@ -256,6 +256,7 @@ last_reviewed: 2026-05-20
 | 進行状態 | `speedad-tutorial-progress` | `localStorage` | 現在のステップ番号、各入力ステップで自動入力した値 | 完了到達／スキップ確定で削除 |
 | 完了フラグ | `speedad-tutorial-completed` | `localStorage` | boolean | 永続（明示的なリセットまで） |
 | 引継ぎ用 | `speedad-tutorial-handoff` | `localStorage` | ブロック B モーダルで入力した基本情報（`surveyName` / `displayTitle` / `periodStart` / `periodEnd` / `memo`）の JSON 文字列 | ステップ 9 マウント時に読み出して即削除（一度きり）|
+| お試し種別 | `speedad-tutorial-entry` | `localStorage` | 公開サイトからのお試しアクセス（`?trial=1`）か否か（`trial` / `standard`） | 完了到達／スキップ確定で削除 |
 
 - 進行状態は `localStorage` に保存し、リロード・タブ閉じ・別タブ・別セッション間で引き継ぐ。
 - 引継ぎ用 `speedad-tutorial-handoff` は、ステップ 8 で「作成する」を押した瞬間にモーダル入力値を保存し、`05_support/tutorial/surveyCreation.html?step=9` 到達時に作成画面側のフィールド（`#surveyName_ja` / `#displayTitle_ja` / `#periodRange`）へ注入してから削除する。ページ間で URL クエリに値を載せずに済ませる経路。
@@ -274,9 +275,19 @@ last_reviewed: 2026-05-20
 | 中断後の再ログイン | 未設定 | 有 | ログイン直後に `tutorial/` 配下の該当ページの `?tutorial=1&step=N` へ遷移、保存ステップから再開 |
 | 完了済みユーザーのログイン | true | — | 通常どおり `02_dashboard/index.html` へ遷移する |
 | `?tutorial=1` 付き URL の直接アクセス | — | — | 完了フラグの有無にかかわらず再生する（QA・確認用途）。完了フラグは自動更新しない |
+| 公開サイトからのお試しアクセス | — | — | 公開トップ・サポートサイトの「チュートリアル」導線（`?trial=1` 付き）から起動。お試しモードで再生し、完了・スキップ時はアカウント作成導線（§7.1）へ接続する |
 
 - 初回ログイン判定は本番ではサーバー側の `first_login` フラグで行う（§13）。モックアップ段階では `localStorage` の完了フラグの有無で代替する。
 - 既存の `04_first-login/index.html`（ウェルカム画面）は本仕様では使用しない。本書策定後に廃止または「始める」ボタン 1 つに簡素化する方針で開発会社と確認する。
+
+### 7.1 お試しユーザーのアカウント作成導線
+
+- アカウント未保有のユーザーが、公開トップ（`index.html`）およびサポートサイト共通フッターの「チュートリアル」リンクからチュートリアルを体験できる。これらの導線リンクには `?trial=1` を付与する。
+- `?trial=1` 付きで起動したセッションを「お試しモード」とし、フレッシュ起動時に種別を `localStorage`（`speedad-tutorial-entry`、§6）へ保存する。中断再開・ページ跨ぎでは保持する。
+- お試しモードでは、完了（ブロック D 最終ステップ）・スキップ確定・ようこそ画面「あとで」のいずれの離脱でも `02_dashboard/index.html` へは遷移せず、全画面の「アカウント作成 CTA 画面」を表示する（§9 の既定の退出先を上書きする）。
+- CTA 画面は 2 アクション: 「アカウントを作成」（公開トップのサインアップ `index.html?intent=signup` へ遷移）／「閉じる」（公開トップ `index.html` へ遷移）。
+- 初回ログイン経由（アカウント保有者）のセッションは従来どおり、完了・スキップ時に `02_dashboard/index.html` へ遷移する。
+- 本番では公開サイトとアプリ（`02_dashboard/`）がドメインを跨ぐため、CTA からサインアップへの遷移先は絶対 URL とする（§13.1 と同じ論点）。
 
 ## 8. 視覚仕様
 

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
             <div class="capability-item__body">
               <h3>チュートリアルで迷わず使える</h3>
               <p>ヘルプ、FAQ、チュートリアルから、基本操作や困ったときの対処を確認できます。</p>
-              <a class="capability-item__link" href="05_support/tutorial/index.html">チュートリアルを見る <span aria-hidden="true">→</span></a>
+              <a class="capability-item__link" href="05_support/tutorial/index.html?trial=1">チュートリアルを見る <span aria-hidden="true">→</span></a>
             </div>
           </article>
         </div>


### PR DESCRIPTION
## 概要
チュートリアル（05_support/tutorial/）の改善。レビュー指摘の修正、終盤フローの再構成、お試しユーザー向けアカウント作成導線の追加。

## 主な変更

### レビュー指摘の修正
- ハイライトのモーダル/アニメーション追従（ResizeObserver・transitionend）
- フォーカストラップの実装、クリックガードの isTrusted 判定
- 設問タイプメニューの開閉不具合、選択肢の自動入力 ほか

### 終盤フローの再構成
- ブロックD を プレビュー→QR→保存→完了 の全30ステップへ
- プレビュー用に survey-answer.html をバンドルへ同梱

### お試しユーザー導線
- ?trial=1 を検知し、完了/スキップ時にアカウント作成CTAを表示

## 検証
- 全30ステップを実機（Playwright）で通し確認
- ハイライト座標・モーダル開閉・保存→完了→遷移・お試しCTAの分岐を確認

## 補足（別タスク）
- トライアル導線リンクへの ?trial=1 付与（入口の場所が未確定）
- 仕様書 31_tutorial_requirements.md への節追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)