### PR TITLE
fix: チュートリアル緊急脱出時の二重進行を修正

### DIFF
--- a/05_support/tutorial/src/tutorial/index.js
+++ b/05_support/tutorial/src/tutorial/index.js
@@ -517,16 +517,25 @@ function cleanupActiveStep() {
 
 function handleNext() {
   // #18: 緊急脱出（stuck hint 経由の前進）時、対象要素が存在すれば本来のクリックを
-  // 代行してから前進する。対象が無ければ前進のみ。
+  // 代行する。対象が無ければ前進のみ。
   if (escapeTargetEl) {
     const el = escapeTargetEl;
     escapeTargetEl = null;
+    // クリック代行で currentStepIndex が変わり得るため、現ステップを先に控える。
+    const stepBeforeClick = TUTORIAL_STEPS[currentStepIndex];
     if (document.body.contains(el)) {
       try {
         el.click();
       } catch (_e) {
         /* noop: クリック失敗時も前進は継続 */
       }
+    }
+    // user-action-bridge は本番ハンドラ（§5.4 ガード）がクリックを受けて
+    // goToStep / redirect で進行を引き継ぐ。ここで advanceStep すると二重進行になり、
+    // ステップ 30 の緊急脱出で完了ステップ（31）が飛ばされてしまう。
+    // ブリッジ系ではクリック代行のみとし、前進はガードに委ねる。
+    if (stepBeforeClick && stepBeforeClick.mode === 'user-action-bridge') {
+      return;
     }
   }
   advanceStep();


### PR DESCRIPTION
## 概要

チュートリアルの緊急脱出（stuck hint 経由の「次へ」）を `user-action-bridge` ステップで押したときに進行が二重に走る不具合を修正する。

## 不具合

`handleNext()` は緊急脱出時に `escapeTargetEl` のクリックを代行したうえで `advanceStep()` も呼んでいた。`user-action-bridge` ステップ（ステップ8・30）では、クリックを受けた本番ハンドラ（§5.4 ガード）が `goToStep` / `redirect` で自前に進行するため、`advanceStep()` と二重進行になっていた。

特に**ステップ30**では次のように完了ステップが飛ばされていた:

1. 緊急脱出の「次へ」押下 → `#createSurveyBtn` をクリック代行
2. ガード `handleAttemptSave()` が `goToStep(31)` を実行
3. `handleNext` が続けて `advanceStep()` → 次ステップ無し → `finishAndExit()`

結果、**完了画面（ステップ31）が一瞬で飛ばされて終了**していた。

## 修正

`handleNext()` を以下のように変更:

- クリック代行の前に現ステップを `stepBeforeClick` として控える（クリックで `currentStepIndex` が変わり得るため）
- 現ステップが `user-action-bridge` の場合は、クリック代行のみ行い `advanceStep()` を呼ばず早期 return（進行はガードに委ねる）
- 通常の `user-action` ステップは従来どおり「クリック＋前進」を維持

## 未確認事項

動作確認は未実施（環境に Node が無くチュートリアルバンドルを起動できないため、ロジック確認のみ）。マージ後の手動検証推奨: ステップ30 で約4秒待って「次へ」を押し、完了画面（ステップ31）が表示されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
