### PR TITLE
fix(tutorial): mask暗幕とspotlight枠のコントラスト強化

### DIFF
--- a/05_support/tutorial/src/tutorial/overlay.js
+++ b/05_support/tutorial/src/tutorial/overlay.js
@@ -588,7 +588,7 @@ function buildMask() {
   blackOut.setAttribute('y', '0');
   blackOut.setAttribute('width', '100%');
   blackOut.setAttribute('height', '100%');
-  blackOut.setAttribute('fill', 'rgba(0, 0, 0, 0.55)');
+  blackOut.setAttribute('fill', 'rgba(0, 0, 0, 0.7)');
   blackOut.setAttribute('mask', 'url(#tutorial-mask-cutout)');
   svg.appendChild(blackOut);
 

--- a/05_support/tutorial/src/tutorial/tutorial.css
+++ b/05_support/tutorial/src/tutorial/tutorial.css
@@ -86,27 +86,27 @@
   position: fixed;
   pointer-events: none;
   z-index: 9030;
-  border: 2px solid var(--tut-accent-cyan);
+  border: 3px solid var(--tut-accent-cyan);
   border-radius: 8px;
   box-shadow:
-    0 0 0 1px rgba(66, 133, 244, 0.35),
-    0 0 4px 1px var(--tut-accent-cyan-glow),
-    0 0 8px 2px rgba(66, 133, 244, 0.22);
+    0 0 0 2px rgba(66, 133, 244, 0.50),
+    0 0 8px 3px var(--tut-accent-cyan-glow),
+    0 0 16px 6px rgba(66, 133, 244, 0.35);
   animation: tutorial-spotlight-pulse 1.6s ease-in-out infinite;
 }
 
 @keyframes tutorial-spotlight-pulse {
   0%, 100% {
     box-shadow:
-      0 0 0 1px rgba(66, 133, 244, 0.35),
-      0 0 4px 1px var(--tut-accent-cyan-glow),
-      0 0 6px 2px rgba(66, 133, 244, 0.18);
+      0 0 0 2px rgba(66, 133, 244, 0.50),
+      0 0 8px 3px var(--tut-accent-cyan-glow),
+      0 0 14px 5px rgba(66, 133, 244, 0.32);
   }
   50% {
     box-shadow:
-      0 0 0 1px rgba(66, 133, 244, 0.55),
-      0 0 8px 3px var(--tut-accent-cyan-glow),
-      0 0 12px 5px rgba(66, 133, 244, 0.32);
+      0 0 0 2px rgba(66, 133, 244, 0.75),
+      0 0 14px 5px var(--tut-accent-cyan-glow),
+      0 0 24px 9px rgba(66, 133, 244, 0.48);
   }
 }
 


### PR DESCRIPTION
## 背景

step 23（タブレット切替）等、モーダル内のボタンをターゲットにする場合に、ユーザーが「ハイライトされていない（明るくなっていない）」と認識する問題が報告された。

## 原因

実装としてはマスク（暗幕）もspotlight枠も正しく描画されていたが、以下の理由でコントラストが弱く視認性が低かった:

- mask 暗幕 `rgba(0,0,0,0.55)` がモーダル白背景 (rgba(255,255,255,1)) と合成して灰色程度に → 「暗幕がかかっている」と認識されにくい
- spotlight 枠 2px + 控えめ glow が、modal の primary color (青) と紛れて見えにくい

## 修正

- mask 暗幕の opacity: 0.55 → **0.7** で背景を確実に暗くする
- spotlight border: 2px → **3px** で枠を太く
- spotlight box-shadow を基本/pulse 両方で**約1.5倍**強化（glow 半径と alpha 値を増加）

## 検証

Playwright で step 21 → プレビュー → step 22 → step 23 と進めて、タブレットボタン周囲に明確なハイライト＋背景暗幕を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)