### PR TITLE
fix(tutorial): タブレット表示の確認 step を分離（26→27 step）

### DIFF
--- a/05_support/tutorial/src/tutorial/guards.js
+++ b/05_support/tutorial/src/tutorial/guards.js
@@ -5,7 +5,7 @@
 //   - isActive()                   : ?tutorial=1 が URL に付いているか
 //   - shouldBlock(action)          : チュートリアル中に本番ハンドラを止めるべきか
 //   - handleCreateSurveyFromModal  : 「作成する」差し替え（surveyCreation.html?tutorial=1&step=9 へ）
-//   - handleAttemptSave            : 「アンケートを保存する」差し替え（保存後 → ステップ 26 完了へ）
+//   - handleAttemptSave            : 「アンケートを保存する」差し替え（保存後 → ステップ 27 完了へ）
 //   - isCompleted()                : 完了フラグ
 //
 // 内部処理（チュートリアル進行の続行）は index.js から注入される _internal フック経由で行う。
@@ -82,13 +82,13 @@ const api = {
 
   /**
    * 「アンケートを保存する」差し替え。本番ハンドラは showToast のみで画面遷移しないため、
-   * チュートリアル側で完了ステップ（26）への進行を実行する。
+   * チュートリアル側で完了ステップ（27）への進行を実行する。
    */
   handleAttemptSave() {
     if (!isActiveNow()) return;
     enableQrButton();
     if (typeof internalHooks.goToStep === 'function') {
-      internalHooks.goToStep(26);
+      internalHooks.goToStep(27);
     }
   },
 

--- a/05_support/tutorial/src/tutorial/steps.js
+++ b/05_support/tutorial/src/tutorial/steps.js
@@ -1,5 +1,5 @@
 // steps.js
-// チュートリアル全 26 ステップ定義（旧34stepから構造圧縮：選択肢一括autofill、関連設定統合、プレビュー操作圧縮）
+// チュートリアル全 27 ステップ定義（旧34stepから構造圧縮：選択肢一括autofill、関連設定統合、プレビュー操作圧縮）
 //
 // 各ステップフィールド:
 //   id, block, target, contextTarget, mode, placement, title, body
@@ -12,8 +12,9 @@
 //   hideBack           : 戻るボタン非表示（ページ境界）
 //   completeButtonLabel: 次へボタンを完了ラベルに差し替え
 //
-// id 8, 25, 26 は user-action-bridge（本番ハンドラ経由 or 完了）。
-// 旧10は新10〜13に分割（名刺画像添付/名刺データ化/お礼メール/回答完了画面）、旧17-20（選択肢4個別）は新17に統合（multi-option一括）、旧23-25（評定尺度3個別）は新20に統合（rating-bundle一括）、旧28-29は新23に統合、旧30/32は廃止しonLeaveActionで自動close（新23/24）。
+// id 8, 26, 27 は user-action-bridge（本番ハンドラ経由 or 完了）。
+// step 23（タブレット切替 user-action）+ step 24（タブレット表示確認 info, onLeaveActionでプレビュー閉じ）に分離。
+// 旧10は新10〜13に分割（名刺画像添付/名刺データ化/お礼メール/回答完了画面）、選択肢4個別は新17に統合（multi-option一括）、評定尺度3個別は新20に統合（rating-bundle一括）、QRモーダル閉じるはonLeaveActionで自動close（新25→26遷移時）。
 
 const TOMORROW_OFFSET_DAYS = 1;
 const PERIOD_LENGTH_DAYS = 3;
@@ -167,23 +168,29 @@ export const TUTORIAL_STEPS = [
   {
     id: 23, block: 'D', target: '#v2-preview-tablet-btn', waitForElement: true,
     mode: 'user-action', placement: 'bottom',
-    onLeaveAction: 'closePreviewModal',
-    title: 'タブレット表示で確認',
-    body: '展示会では来場者がスマートフォンで読み取ったり、ブースのタブレットで回答したりします。『タブレット』ボタンを押して、タブレットでの見え方を確認してください。',
+    title: 'タブレット表示に切り替える',
+    body: '展示会では来場者がスマートフォンで読み取ったり、ブースのタブレットで回答したりします。『タブレット』ボタンを押して、見え方を切り替えてください。',
   },
   {
-    id: 24, block: 'D', target: '#openQrModalBtn', mode: 'user-action', placement: 'left',
+    id: 24, block: 'D', target: '#surveyPreviewModalV2 .modal-content-transition', waitForElement: true,
+    mode: 'info', placement: 'left',
+    onLeaveAction: 'closePreviewModal',
+    title: 'タブレット表示を確認',
+    body: 'タブレットでの見え方に切り替わりました。スマートフォンとの違いを確認できます。確認できたら、下の『次へ』ボタンを押してください。',
+  },
+  {
+    id: 25, block: 'D', target: '#openQrModalBtn', mode: 'user-action', placement: 'left',
     onLeaveAction: 'closeQrModal',
     title: 'QR コードを表示',
     body: '回答用のQRコードを表示してみましょう。これは来場者にスマートフォンで読み取ってもらい、アンケートに回答してもらうためのQRコードです。『QR発行』ボタンを押してください。',
   },
   {
-    id: 25, block: 'D', target: '#createSurveyBtn', mode: 'user-action-bridge', placement: 'left',
+    id: 26, block: 'D', target: '#createSurveyBtn', mode: 'user-action-bridge', placement: 'left',
     title: 'アンケートを保存する',
     body: '画面右側の『アンケートを保存する』ボタンを押してください。保存してもこの画面のまま、ダッシュボードへ自動では移動しません。（練習のため実際には保存されません）',
   },
   {
-    id: 26, block: 'D', target: null, mode: 'user-action-bridge', placement: 'center',
+    id: 27, block: 'D', target: null, mode: 'user-action-bridge', placement: 'center',
     title: 'チュートリアル完了',
     body: 'お疲れさまでした。これでアンケート作成の基本フローは完了です。アカウントを作成すると、今練習したものを実際に公開して回答を集められます。下の『完了』ボタンを押してください。',
     completeButtonLabel: '完了',


### PR DESCRIPTION
## 背景

step 23 で「タブレット」ボタンをクリックすると、ユーザーがタブレット表示を確認する前に即座に次（QR表示）へ進んでしまっていた。

## 修正

- **step 23**: 「タブレット表示に切り替える」（user-action: クリックのみ）
- **新 step 24**: 「タブレット表示を確認」（info: 「次へ」で進む。onLeaveAction で次stepに進む際にプレビューモーダル自動close）
- 後続step を +1 シフト（旧24→25 QR、旧25→26 保存、旧26→27 完了）
- [guards.js](05_support/tutorial/src/tutorial/guards.js): `handleAttemptSave` の `goToStep(26)` → `(27)`

## 検証

Playwright で:
- step 23 タブレットクリック → step 24 「タブレット表示を確認」 info に遷移 ✓
- モーダルは flex のまま開いていて、タブレット表示が見られる ✓
- 「次へ」を押すと step 25 (QR) へ進み、その時にプレビューモーダルが自動close ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)