### PR TITLE
fix: ログイン前ページのお知らせ帯を1920×1080のファーストビューに収める

### DIFF
--- a/css/login-front.css
+++ b/css/login-front.css
@@ -1132,15 +1132,22 @@ img {
   display: none !important;
 }
 
+@media (min-width: 1101px) {
+  .hero,
+  .hero__inner {
+    min-height: calc(100vh - 85px);
+  }
+}
+
 .public-news-bar {
   width: min(1160px, calc(100% - 112px));
-  min-height: 98px;
+  min-height: 52px;
   margin: 0 auto;
   display: grid;
   grid-template-columns: 116px minmax(0, 1fr) 106px;
   gap: 16px;
   align-items: center;
-  padding: 18px clamp(24px, 4vw, 36px) 16px;
+  padding: 4px clamp(24px, 4vw, 36px) 4px;
 }
 
 .public-news-bar__heading {
@@ -1176,7 +1183,7 @@ img {
 
 .public-news-item {
   display: block;
-  min-height: 56px;
+  min-height: 44px;
   padding: 0 14px;
   border-right: 1px solid var(--line);
   color: var(--ink);


### PR DESCRIPTION
## 概要
1920×1080のフルHD初期表示で、ログイン前ページのお知らせ帯がスクロールなしでは見えていなかったのを修正。ヒーローを画面の約9割に保ちつつ、帯がファーストビュー下端にしっかり収まる塩梅に調整。

## 変更内容
- `@media (min-width: 1101px)` で `.hero` / `.hero__inner` の `min-height` を `calc(100vh - 85px)` に上書き
- `.public-news-bar` を `min-height: 52px` / `padding: 4px clamp(24px,4vw,36px)` に絞る
- `.public-news-item` の `min-height` を `44px`（タップ領域の推奨値）に
- タブレット・スマホ（≤1100px）は従来通り（媒体での挙動は変更なし）

## 想定サイズ（1920×1080 / Chrome 実ビューポート ≈920px）
- ヒーロー ≈ 835px（画面の約91%）
- お知らせ帯 ≈ 52px
- 帯下の余白 ≈ 33px

## 対象ファイル
- `css/login-front.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)