### PR TITLE
chore: Playwright による E2E テスト環境をセットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ tmp-*.png
 /output/
 /test-results/
 /.pwtest/
+/playwright-report/
+/blob-report/
 
 # Local reference materials
 /00_Abroad⇔Rep/SPEEDレビュー・グラフ分析・請求書関連QA.xlsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,78 @@
 {
-  "name": "SPPED-AD-TEST",
+  "name": "spped-ad-test",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "node_modules/tailwindcss": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
-      "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
+    "": {
+      "name": "spped-ad-test",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
-      "license": "MIT"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spped-ad-test",
+  "version": "0.0.0",
+  "private": true,
+  "description": "SPEED AD 静的モックの E2E テスト (Playwright)",
+  "scripts": {
+    "serve": "python scripts/dev-server.py 8765",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:install": "playwright install"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.59.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,60 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * SPEED AD E2E テスト設定。
+ *
+ * 静的モックを scripts/dev-server.py (port 8765) で配信し、その上で
+ * 利用者導線を確認する。対象フローは
+ * 99_backend-docs/08_e2e-testing/02_target-flows.md を参照。
+ *
+ * 環境変数 BASE_URL を渡すと dev/stg などの外部環境にも向けられる
+ * （その場合 webServer は reuseExistingServer で起動をスキップ）。
+ */
+const PORT = 8765;
+const BASE_URL = process.env.BASE_URL || `http://127.0.0.1:${PORT}`;
+const useLocalServer = !process.env.BASE_URL;
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox-desktop',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit-desktop',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
+
+  // ローカル静的サーバー。BASE_URL 指定時は外部環境を使うため起動しない。
+  webServer: useLocalServer
+    ? {
+        command: `python scripts/dev-server.py ${PORT}`,
+        url: BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 30 * 1000,
+      }
+    : undefined,
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,40 @@
+# E2E テスト (Playwright)
+
+SPEED AD 静的モックの利用者導線を Playwright で確認する。
+対象フローの定義は [99_backend-docs/08_e2e-testing/02_target-flows.md](../../99_backend-docs/08_e2e-testing/02_target-flows.md) を参照。
+
+## 前提
+
+- Node.js / npm
+- Python（ローカル配信 `scripts/dev-server.py` 用）
+- 初回のみ依存とブラウザを取得:
+  ```
+  npm install
+  npm run test:e2e:install   # chromium / firefox / webkit
+  ```
+
+## 実行
+
+| コマンド | 内容 |
+| --- | --- |
+| `npm run test:e2e` | 全プロジェクトで実行（ローカルサーバーは自動起動） |
+| `npm run test:e2e:ui` | UI モードで実行 |
+| `npm run test:e2e:headed` | ブラウザ表示ありで実行 |
+| `npm run test:e2e:report` | 直近の HTML レポートを表示 |
+
+特定ブラウザのみ: `npx playwright test --project=chromium-desktop`
+
+## 設定の要点（[playwright.config.js](../../playwright.config.js)）
+
+- `webServer`: `python scripts/dev-server.py 8765` を自動起動し `http://127.0.0.1:8765` を配信。
+- 外部環境に向ける場合は `BASE_URL` を指定（webServer は起動しない）:
+  ```
+  $env:BASE_URL="https://stg.speed-ad.com"; npm run test:e2e
+  ```
+  ※ dev/stg/prod での自動操作可否・テストアカウント・副作用ありの操作は要確認。
+- プロジェクト: `chromium-desktop` / `firefox-desktop` / `webkit-desktop` / `mobile-chrome`。
+
+## テストの追加
+
+`tests/e2e/*.spec.js` に追加する。`smoke.spec.js` はセットアップ検証用の最小テスト。
+クリック対象には安定した id / data 属性を優先して使う（テキスト依存を避ける）。

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * セットアップ検証用スモークテスト。
+ *
+ * Playwright とローカル配信 (scripts/dev-server.py) が正しく動くことを
+ * 確認する最小限のテスト。本格的な導線テストは
+ * 99_backend-docs/08_e2e-testing/02_target-flows.md の E2E-FLOW-01〜07 を
+ * 順次このディレクトリに追加していく。
+ */
+
+test('トップページが表示される', async ({ page }) => {
+  const response = await page.goto('/');
+  expect(response?.ok()).toBeTruthy();
+  await expect(page).toHaveTitle(/SPEED AD/);
+});
+
+test('ダッシュボードページが配信される (E2E-FLOW-01 の入口)', async ({ page }) => {
+  const response = await page.goto('/02_dashboard/index.html');
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.locator('body')).toBeVisible();
+});


### PR DESCRIPTION
## 概要

SPEED AD 静的モックの E2E テストを Playwright で実行できる環境をセットアップしました。テストの実行・本格的な導線テストの実装はまだ行っていません（最小スモークのみ）。

対象フロー定義: `99_backend-docs/08_e2e-testing/02_target-flows.md`

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `package.json`（新規） | `@playwright/test@1.59.1` を devDependency に追加。`test:e2e` 系の npm スクリプト |
| `playwright.config.js`（新規） | 4プロジェクト（chromium / firefox / webkit / mobile-chrome）。既存 `scripts/dev-server.py`（port 8765）を webServer として自動起動。`BASE_URL` で dev/stg/prod に切替可（その場合 webServer はスキップ） |
| `tests/e2e/smoke.spec.js`（新規） | セットアップ検証用スモーク（トップページ + ダッシュボード配信、E2E-FLOW-01 の起点） |
| `tests/e2e/README.md`（新規） | 実行手順・設定要点 |
| `.gitignore` | `playwright-report/` `blob-report/` を追加 |

## 確認済み

- `playwright test --list` で 8件（4ブラウザ × 2テスト）を検出。設定読み込み・テスト発見ともに正常
- ブラウザ（chromium / firefox / webkit）はローカルに導入済み。`node_modules` とブラウザ実体は gitignore 済み

## レビュー観点 / 要判断

`99_backend-docs/08_e2e-testing/04_automation-considerations.md` では以下が未確定/対象外とされています。本 PR はその一部を先行導入する位置づけです。

- **ツール標準**: Playwright と Cypress のどちらを標準にするか（本 PR は Playwright を選択）
- **依存追加・テストコード**: 同ドキュメントで「対象外」と明記されていた範囲
- **外部環境での自動操作**: dev/stg/prod の自動操作可否・テストアカウント・副作用ありの操作の分離方法は要確認（本 PR は local 静的モック前提で構築）

Playwright 採用を正式決定する場合、マージ後に 04 ドキュメントの「未確定/対象外」記述を更新して整合させると良いです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)