### PR TITLE
fix: グループ新規作成ボタンを個人アカウントでも表示

### DIFF
--- a/02_dashboard/src/sidebarHandler.js
+++ b/02_dashboard/src/sidebarHandler.js
@@ -199,12 +199,12 @@ function handleGroupChange(selectedId) {
     // Dispatch custom event with the new account type
     document.dispatchEvent(new CustomEvent('accountTypeChanged', { detail: { accountType } }));
 
+    if (newGroupButton) newGroupButton.style.display = '';
+
     if (selectedId === 'personal') {
-        if (newGroupButton) newGroupButton.style.display = 'none';
         if (groupManagementNav) groupManagementNav.style.display = 'none';
         if (currentGroupLabel) currentGroupLabel.style.display = 'none';
     } else {
-        if (newGroupButton) newGroupButton.style.display = '';
         if (groupManagementNav) groupManagementNav.style.display = '';
         if (currentGroupLabel) currentGroupLabel.style.display = '';
         if (selectedGroup) {

--- a/05_support/tutorial/src/sidebarHandler.js
+++ b/05_support/tutorial/src/sidebarHandler.js
@@ -199,12 +199,12 @@ function handleGroupChange(selectedId) {
     // Dispatch custom event with the new account type
     document.dispatchEvent(new CustomEvent('accountTypeChanged', { detail: { accountType } }));
 
+    if (newGroupButton) newGroupButton.style.display = '';
+
     if (selectedId === 'personal') {
-        if (newGroupButton) newGroupButton.style.display = 'none';
         if (groupManagementNav) groupManagementNav.style.display = 'none';
         if (currentGroupLabel) currentGroupLabel.style.display = 'none';
     } else {
-        if (newGroupButton) newGroupButton.style.display = '';
         if (groupManagementNav) groupManagementNav.style.display = '';
         if (currentGroupLabel) currentGroupLabel.style.display = '';
         if (selectedGroup) {


### PR DESCRIPTION
## 概要
個人アカウント選択時に「グループを新規作成」ボタンが表示されない不具合を修正。

## 原因
`handleGroupChange` で個人アカウント時に `newGroupButton` を `display:none` にしていたため、何らかのグループに切り替えた時しか表示されなかった。

## 修正
- `newGroupButton` の表示制御を個人/グループ分岐の外へ出し、常に表示するよう統一
- `groupManagementNav` / `currentGroupLabel` は従来通り個人時は非表示を維持
- チュートリアル版フォーク（05_support/tutorial）も同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)