### PR TITLE
feat(login-front): ログイン前LPをFHDで1ブロック=1ビューポート表示に調整

### DIFF
--- a/css/login-front.css
+++ b/css/login-front.css
@@ -1433,9 +1433,69 @@ body.is-hero-font-dragging * {
 }
 
 @media (min-width: 1101px) {
-  .hero,
-  .hero__inner {
-    min-height: calc(100vh - 85px);
+  /* ログイン前LP: 各ブロックを1ビューポート単位で表示（フルHD 1920x1080想定） */
+
+  /* 1枚目: ヒーロー ＋ お知らせ */
+  .lp-page--first {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .lp-page--first .hero {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+  }
+
+  .lp-page--first .hero__inner {
+    min-height: 0;
+    padding-top: 84px;
+    padding-bottom: 60px;
+  }
+
+  .lp-page--first .public-news-section {
+    flex: 0 0 auto;
+    padding-top: 10px;
+    padding-bottom: 22px;
+  }
+
+  /* 2枚目: SPEED ADでできること ＋ 展示会の流れ（上下2バンドで1画面） */
+  .lp-page--duo {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .lp-page--duo .features-section {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .lp-page--duo .flow-section {
+    flex: 1 1 0;
+    align-content: center;
+  }
+
+  /* 3枚目: 選ばれる理由（セクション自体を画面いっぱいに伸ばし、中身を中央寄せ） */
+  .lp-page--solo {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .lp-page--solo .capabilities-section {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  /* 4枚目: 導入事例（既に100vh設計） */
+  .lp-page--voice .voice-teaser-section {
+    min-height: 100vh;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -10,11 +10,12 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/login-front.css?v=20260525-dashboard-font-hero-serif">
+  <link rel="stylesheet" href="css/login-front.css?v=20260601-fhd-viewport-paging">
 </head>
 <body id="before-login">
   <a class="skip-link" href="#top">本文へスキップ</a>
   <main id="top">
+    <div class="lp-page lp-page--first">
     <section class="hero" aria-labelledby="hero-title">
       <div class="hero__media" aria-hidden="true"></div>
       <div class="hero__shade" aria-hidden="true"></div>
@@ -127,7 +128,9 @@
         <a class="public-news-bar__link" href="05_support/news/" target="_blank" rel="noopener noreferrer">一覧を見る <span aria-hidden="true">↗</span></a>
       </div>
     </section>
+    </div>
 
+    <div class="lp-page lp-page--duo">
     <section class="section-block features-section" aria-labelledby="features-title">
       <div class="section-grid section-grid--intro">
         <div class="section-heading">
@@ -233,7 +236,9 @@
         </li>
       </ol>
     </section>
+    </div>
 
+    <div class="lp-page lp-page--solo">
     <section class="section-block capabilities-section" id="capabilities" aria-labelledby="capabilities-title">
       <div class="section-grid section-grid--capabilities">
         <div class="section-heading">
@@ -336,7 +341,9 @@
         </div>
       </div>
     </section>
+    </div>
 
+    <div class="lp-page lp-page--voice">
     <section class="voice-teaser-section" aria-labelledby="voice-title">
       <div class="voice-teaser-wrap">
         <div class="voice-teaser__intro">
@@ -370,7 +377,9 @@
         <a class="voice-teaser__link" href="customer-voices/index.html">すべての声を見る <span aria-hidden="true">→</span></a>
       </div>
     </section>
+    </div>
 
+    <div class="lp-page lp-page--tail">
     <section class="related-services" aria-labelledby="related-title">
       <div class="related-services__heading">
         <p class="section-kicker" lang="en">OTHER SERVICES</p>
@@ -397,6 +406,7 @@
         <span class="cta-button__arrow" aria-hidden="true">→</span>
       </a>
     </section>
+    </div>
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
## 概要
ログイン前LP（index.html）を、フルHD(1920x1080)で各論理ブロックがそれぞれ1画面に収まるよう調整しました。

## ページ構成（PC ≥1101px）
| 枚 | 内容 |
|---|---|
| 1枚目 | ヒーロー + お知らせ |
| 2枚目 | SPEED ADでできること + 展示会の流れ（上下2バンド） |
| 3枚目 | 選ばれる理由（セクションを画面いっぱいに伸長し中央配置） |
| 4枚目 | 導入事例 |
| 5枚目以降 | 当社サービス + 最終CTA + フッター |

各グループをラッパー`div.lp-page`で囲み、PC幅(≥1101px)で`min-height:100vh`化。各ページが viewport の倍数ちょうどで開始します。

## 変更ファイル
- `index.html` — グループ単位のラッパー追加、CSSキャッシュバスター更新
- `css/login-front.css` — `@media (min-width:1101px)`にページング規則を追加

## 互換性
- タブレット/スマホ(≤1100px)は従来の縦積みを維持（ラッパーは素のblock、`min-height`なし）
- JSのDOM兄弟・親トラバーサル依存なし、子・隣接セレクタへの影響なしを確認

## 検証
- 1920×1080 / 1920×937 の両方で全ページが正確に100vh（実測）
- 各ページのスクリーンショットで表示崩れ・白地・上寄りがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)