### PR TITLE
feat(login-front): LPにフルページ・ホイールナビと導入事例の高さ微調整

### DIFF
--- a/css/login-front.css
+++ b/css/login-front.css
@@ -1434,6 +1434,14 @@ body.is-hero-font-dragging * {
 
 @media (min-width: 1101px) {
   /* ログイン前LP: 各ブロックを1ビューポート単位で表示（フルHD 1920x1080想定） */
+  /* スクロール吸い寄せ（中: proximity＝自由スクロールを保ちつつ各ページに緩く吸着） */
+  html {
+    scroll-snap-type: y proximity;
+  }
+
+  .lp-page {
+    scroll-snap-align: start;
+  }
 
   /* 1枚目: ヒーロー ＋ お知らせ */
   .lp-page--first {
@@ -1493,9 +1501,9 @@ body.is-hero-font-dragging * {
     justify-content: center;
   }
 
-  /* 4枚目: 導入事例（既に100vh設計） */
+  /* 4枚目: 導入事例（100vh + 約1cm 下方向に余裕を持たせる） */
   .lp-page--voice .voice-teaser-section {
-    min-height: 100vh;
+    min-height: calc(100vh + 38px);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/login-front.css?v=20260601-fhd-viewport-paging">
+  <link rel="stylesheet" href="css/login-front.css?v=20260601-fhd-snap-voice">
 </head>
 <body id="before-login">
   <a class="skip-link" href="#top">本文へスキップ</a>
@@ -527,5 +527,6 @@
   </div>
 
   <script src="js/login-front.js?v=20260527-inline-text-edit" defer></script>
+  <script src="js/login-front-fullpage.js?v=20260601-fullpage" defer></script>
 </body>
 </html>

--- a/js/login-front-fullpage.js
+++ b/js/login-front-fullpage.js
@@ -1,0 +1,72 @@
+/**
+ * ログイン前LP: フルページ・ホイールナビゲーション
+ * 少しのスクロールで隣接する .lp-page へスムーズに移動する（1ホイール=1ページ）。
+ * - PC幅(>=1101px)のみ有効。タブレット/スマホは通常スクロール。
+ * - prefers-reduced-motion 指定時は無効（通常スクロール）。
+ * - モック切替パネル(.hero-copy-picker)上では横取りしない。
+ */
+(function () {
+  'use strict';
+
+  var MIN_WIDTH = 1101;
+  var COOLDOWN_MS = 850; // 連続発火を抑え、1ジェスチャー=1ページ移動にする
+  var DELTA_THRESHOLD = 3;
+
+  var motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  var widthQuery = window.matchMedia('(min-width: ' + MIN_WIDTH + 'px)');
+  var lastNav = 0;
+
+  function enabled() {
+    return widthQuery.matches && !motionQuery.matches;
+  }
+
+  function pages() {
+    return Array.prototype.slice.call(document.querySelectorAll('.lp-page'));
+  }
+
+  function currentIndex(list) {
+    var y = window.scrollY || window.pageYOffset || 0;
+    var best = 0;
+    var bestDist = Infinity;
+    for (var i = 0; i < list.length; i++) {
+      var dist = Math.abs(list[i].offsetTop - y);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  function goTo(list, index) {
+    var clamped = Math.max(0, Math.min(list.length - 1, index));
+    list[clamped].scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function onWheel(event) {
+    if (!enabled()) {
+      return;
+    }
+    if (event.target && event.target.closest && event.target.closest('.hero-copy-picker')) {
+      return; // モックツールの内部スクロールは尊重
+    }
+    event.preventDefault();
+
+    if (Math.abs(event.deltaY) < DELTA_THRESHOLD) {
+      return;
+    }
+    var now = performance.now();
+    if (now - lastNav < COOLDOWN_MS) {
+      return;
+    }
+    var list = pages();
+    if (list.length === 0) {
+      return;
+    }
+    lastNav = now;
+    var direction = event.deltaY > 0 ? 1 : -1;
+    goTo(list, currentIndex(list) + direction);
+  }
+
+  window.addEventListener('wheel', onWheel, { passive: false });
+})();


### PR DESCRIPTION
## 概要
ログイン前LPに「少しのスクロールで1ページ移動するアニメーション」を追加し、導入事例の高さを微調整しました。

## 変更点
- **`js/login-front-fullpage.js`（新規）**: ホイール操作で隣接`.lp-page`へスムーズスクロール（1ホイール=1ページ）
  - PC(≥1101px)のみ有効 / `prefers-reduced-motion`時は無効
  - クールダウン850msで連続発火による飛ばしを防止
  - モック切替パネル(`.hero-copy-picker`)上では横取りしない
- **`css/login-front.css`**: `scroll-snap`(proximity)をキーボード/スクロールバー整列用に併存。導入事例を`100vh + 38px`（約1cm）下方向に延長
- **`index.html`**: スクリプト追加・CSSキャッシュバスター更新

## 検証
- Playwrightで小さなホイール(delta 12〜18)→1ページずつ移動、連続3発でも1ページのみ移動を確認
- 1080 / 937 / 912 のいずれでも1枚目に hero＋お知らせが収まることを実測

🤖 Generated with [Claude Code](https://claude.com/claude-code)