### PR TITLE
不具合一覧のBacklog番号をリンク化

### DIFF
--- a/99_backend-docs/13_prod-stg-defects/index.html
+++ b/99_backend-docs/13_prod-stg-defects/index.html
@@ -253,7 +253,7 @@
     body.innerHTML = DEFECTS.map((d, index) => `
       <tr class="defect-row border-b border-outline-variant" data-index="${index}" tabindex="0" role="button" aria-label="${escapeHtml(d.key)} の詳細を開く">
         <td class="px-3 py-2 align-top">${chip(d.p, PRIORITY_CLASS)}</td>
-        <td class="whitespace-nowrap px-3 py-2 align-top font-medium text-on-surface">${escapeHtml(d.key)}</td>
+        <td class="whitespace-nowrap px-3 py-2 align-top font-medium"><a class="backlog-link inline-flex items-center gap-1 text-primary underline decoration-dotted underline-offset-2 hover:opacity-80" href="${BACKLOG_BASE + encodeURIComponent(d.key)}" target="_blank" rel="noopener" aria-label="${escapeHtml(d.key)} をBacklogで開く">${escapeHtml(d.key)}<span class="material-icons text-sm">open_in_new</span></a></td>
         <td class="px-3 py-2 align-top">${chip(d.prod, ENV_CLASS)}</td>
         <td class="px-3 py-2 align-top">${chip(d.stg, ENV_CLASS)}</td>
         <td class="px-3 py-2 align-top leading-6 text-on-surface">${escapeHtml(d.sum)}</td>
@@ -263,6 +263,10 @@
     `).join('');
 
     document.getElementById('rowCount').textContent = `${DEFECTS.length}件`;
+
+    body.querySelectorAll('.backlog-link').forEach(link => {
+      link.addEventListener('click', event => event.stopPropagation());
+    });
 
     body.querySelectorAll('.defect-row').forEach(row => {
       const d = DEFECTS[Number(row.dataset.index)];


### PR DESCRIPTION
本番・STG不具合一覧（99_backend-docs/13_prod-stg-defects）のBacklog番号を、該当課題への直リンクに変更。

## 変更点
- Backlog列の課題キー（例: SPDAD2026-167）を `https://repinc.backlog.com/view/<キー>` への直リンクに（別タブ）。下線＋open_in_newアイコン付き。
- 既存の行クリック→詳細モーダルは維持。リンククリック時は stopPropagation でモーダルを開かず遷移のみ。
- リンク先ベースURLは既存 BACKLOG_BASE を流用（モーダルの「Backlogで開く」と一致）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)