### PR TITLE
fix(dashboard): アンケートプレビューV2モーダルの404を解消

### DIFF
--- a/02_dashboard/modals/surveyPreviewModalV2.html
+++ b/02_dashboard/modals/surveyPreviewModalV2.html
@@ -1,0 +1,58 @@
+<div id="surveyPreviewModalV2" class="modal-overlay" data-state="closed">
+  <div class="modal-content-transition modal-content w-full max-w-4xl rounded-xl bg-surface shadow-lg relative flex flex-col" style="height: 90vh; max-height: 90vh;">
+    <!-- Header -->
+    <div class="flex items-center justify-between px-6 py-4 border-b border-outline-variant flex-shrink-0">
+      <h2 class="text-on-surface text-lg font-bold">アンケートプレビュー</h2>
+      <div class="flex items-center gap-2">
+        <!-- Device switcher -->
+        <div class="flex items-center border border-outline-variant rounded-full p-0.5 bg-surface-variant" id="v2-preview-device-switcher">
+          <button id="v2-preview-phone-btn" type="button" title="スマートフォン"
+            class="px-3 py-1.5 rounded-full flex items-center gap-1 text-xs font-bold transition-colors bg-surface text-on-surface shadow-sm">
+            <span class="material-icons text-[16px]">smartphone</span>
+          </button>
+          <button id="v2-preview-tablet-btn" type="button" title="タブレット"
+            class="px-3 py-1.5 rounded-full flex items-center gap-1 text-xs font-bold transition-colors text-on-surface-variant hover:bg-surface">
+            <span class="material-icons text-[16px]">tablet_mac</span>
+          </button>
+        </div>
+        <button type="button" data-modal-close="surveyPreviewModalV2" class="text-on-surface-variant hover:text-on-surface transition-colors ml-2">
+          <span class="material-icons text-2xl">close</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Preview mode banner -->
+    <div class="flex items-center justify-center gap-2 bg-amber-400 text-white text-xs font-bold px-4 py-1.5 flex-shrink-0">
+      <span class="material-icons text-[14px]">info</span>
+      プレビューモード — 回答データは送信されません
+    </div>
+
+    <!-- Body: iframe -->
+    <div class="flex-1 overflow-auto flex items-center justify-center bg-gray-100 p-6 min-h-0">
+      <div id="v2-preview-device-frame"
+        class="bg-white rounded-2xl shadow-xl overflow-hidden transition-all duration-300 flex flex-col flex-shrink-0"
+        style="width: 390px; height: 844px;">
+        <!-- Device top bar (decorative) -->
+        <div class="bg-gray-800 flex-shrink-0 flex items-center justify-center py-1.5 gap-2">
+          <div class="w-16 h-1.5 bg-gray-600 rounded-full"></div>
+          <div class="w-2 h-2 bg-gray-600 rounded-full"></div>
+        </div>
+        <iframe
+          id="surveyPreviewIframe"
+          src="about:blank"
+          class="flex-1 border-none w-full"
+          style="min-height: 0;"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups">
+        </iframe>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="flex justify-end px-6 py-3 border-t border-outline-variant flex-shrink-0">
+      <button type="button" data-modal-close="surveyPreviewModalV2"
+        class="px-6 py-2.5 rounded-full bg-secondary-container text-on-secondary-container text-sm font-bold transition-colors hover:opacity-90">
+        閉じる
+      </button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
アンケート作成画面のプレビュー表示時に発生していた 404 エラーを解消します。

## 原因
`02_dashboard/src/surveyCreation-v2.js` が `modals/surveyPreviewModalV2.html` を要求していますが、`02_dashboard/modals/` には旧版 `surveyPreviewModal.html`（V2なし）しか存在せず、404 になっていました。コールバックは V2 専用 ID（`v2-preview-phone-btn` / `v2-preview-tablet-btn` / `v2-preview-device-frame`）を参照するため、旧 V1 では動作しません。

## 対応
- `02_dashboard/modals/surveyPreviewModalV2.html` を新規追加（コールバックが参照する `v2-` プレフィックスの ID を持つ）

## 確認方法
1. ダッシュボードのアンケート作成画面を開く
2. プレビューボタンを押す
3. モーダルが開き、スマホ/タブレットのデバイス切り替えが動作することを確認

## 補足
- 旧 V1 `02_dashboard/modals/surveyPreviewModal.html` は参照されなくなった孤立ファイルですが、本PRでは削除せず残しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)