### PR TITLE
fix(survey): 設問タイプ表示名を「画像添付」へ変更

### DIFF
--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -164,7 +164,7 @@ const QUESTION_TYPES = {
   matrix_ma:        { label: 'マトリックス(MA)',  icon: 'grid_view' },
   date_time:        { label: '日付/時間',         icon: 'event' },
   handwriting:      { label: '手書きスペース',    icon: 'draw' },
-  image:            { label: '画像アップロード',  icon: 'photo_camera' },
+  image:            { label: '画像添付',        icon: 'photo_camera' },
   explanation_card: { label: '説明カード',        icon: 'info_outline' },
 };
 
@@ -1462,7 +1462,7 @@ function buildHandwritingSection(q, typeLabel) {
   return section;
 }
 
-// 回答設定を持たないタイプ（画像アップロード・説明カード）用のスリム表示。
+// 回答設定を持たないタイプ（画像添付・説明カード）用のスリム表示。
 // タイプ変更バッジ（typeLabel）の置き場は維持し、ダミーの設定ボックスは出さない
 function buildNoSettingsSection(q, typeLabel, note) {
   const section = el('section', { class: 'px-5 pb-5 border-t border-gray-100 pt-4' });

--- a/05_support/tutorial/src/surveyCreation-v2.js
+++ b/05_support/tutorial/src/surveyCreation-v2.js
@@ -156,7 +156,7 @@ const QUESTION_TYPES = {
   matrix_ma:        { label: 'マトリックス(MA)',  icon: 'grid_view' },
   date_time:        { label: '日付/時間',         icon: 'event' },
   handwriting:      { label: '手書きスペース',    icon: 'draw' },
-  image:            { label: '画像アップロード',  icon: 'photo_camera' },
+  image:            { label: '画像添付',        icon: 'photo_camera' },
   explanation_card: { label: '説明カード',        icon: 'info_outline' },
 };
 
@@ -1304,7 +1304,7 @@ function buildHandwritingSection(q, typeLabel) {
   return section;
 }
 
-// 回答設定を持たないタイプ（画像アップロード・説明カード）用のスリム表示。
+// 回答設定を持たないタイプ（画像添付・説明カード）用のスリム表示。
 // タイプ変更バッジ（typeLabel）の置き場は維持し、ダミーの設定ボックスは出さない
 function buildNoSettingsSection(q, typeLabel, note) {
   const section = el('section', { class: 'px-5 pb-5 border-t border-gray-100 pt-4' });


### PR DESCRIPTION
## 概要
設問タイプ image の表示名を「画像アップロード」→「画像添付」に変更（02_dashboard／05_support/tutorial 両方）。

回答者の実操作は写真の撮影またはファイル選択のため「アップロード」の語感と合わない。プレミアム系仕様書（11_plan_feature_restrictions.md・プレミアム構造資料）の呼称「画像添付」へ寄せる。

- 表示名は QUESTION_TYPES の label 1箇所から全UI（追加パレット/FABメニュー/タイプ変更ダイアログ/バッジ/トースト）へ動的反映
- タイプキー `image`・保存フォーマットは変更なし
- 用語棚卸 G-0340（表記ゆれ）の正式判断・00_screen_requirements.md 側の追従は別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)