### PR TITLE
fix(survey): 日付/時間設問の既定を日付・時刻の両方オンに変更

### DIFF
--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -559,7 +559,7 @@ function defaultQuestion(type) {
     base.config = { multiline: true, minLength: '', maxLength: '' };
   }
   if (type === 'date_time') {
-    base.config = { showDate: true, showTime: false };
+    base.config = { showDate: true, showTime: true };
   }
   if (type === 'handwriting') {
     base.config = { height: 200 };
@@ -1474,10 +1474,10 @@ function buildNoSettingsSection(q, typeLabel, note) {
 }
 
 function buildDateTimeSection(q, typeLabel) {
-  if (!q.config) q.config = { showDate: true, showTime: false };
+  if (!q.config) q.config = { showDate: true, showTime: true };
   const cfg = q.config;
   if (cfg.showDate === undefined) cfg.showDate = true;
-  if (cfg.showTime === undefined) cfg.showTime = false;
+  if (cfg.showTime === undefined) cfg.showTime = true;
 
   const section = el('section', { class: 'px-5 pb-5 space-y-4 border-t border-gray-100 pt-4' });
   const hdr = el('div', { class: 'flex items-center justify-between gap-2' });
@@ -2665,7 +2665,7 @@ function buildPreviewData() {
 
     if (q.type === 'date_time') {
       const showDate = cfg.showDate !== false;
-      const showTime = cfg.showTime === true;
+      const showTime = cfg.showTime !== false;
       base.meta = {
         ...base.meta,
         dateTimeConfig: {
@@ -2956,9 +2956,9 @@ async function loadSurveyData(surveyId) {
         base.matrixCols = (q.options || []).map(c => ({ ja: c.text || '' }));
       }
       if (type === 'date_time') {
-        // 保存済みの入力モードから日付/時刻トグルを復元（無ければ旧typeで判定、既定は日付のみ）
+        // 保存済みの入力モードから日付/時刻トグルを復元（無ければ旧typeで判定、既定は日付・時刻の両方）
         const mode = q.meta?.dateTimeConfig?.inputMode || q.inputMode
-          || (q.type === 'time' ? 'time' : q.type === 'date' ? 'date' : 'date');
+          || (q.type === 'time' ? 'time' : q.type === 'date' ? 'date' : 'datetime');
         base.config = mode === 'datetime' ? { showDate: true, showTime: true }
           : mode === 'time' ? { showDate: false, showTime: true }
           : { showDate: true, showTime: false };

--- a/05_support/tutorial/src/surveyCreation-v2.js
+++ b/05_support/tutorial/src/surveyCreation-v2.js
@@ -491,7 +491,7 @@ function defaultQuestion(type) {
     base.config = { multiline: true, minLength: '', maxLength: '' };
   }
   if (type === 'date_time') {
-    base.config = { showDate: true, showTime: false };
+    base.config = { showDate: true, showTime: true };
   }
   if (type === 'handwriting') {
     base.config = { height: 200 };
@@ -1316,10 +1316,10 @@ function buildNoSettingsSection(q, typeLabel, note) {
 }
 
 function buildDateTimeSection(q, typeLabel) {
-  if (!q.config) q.config = { showDate: true, showTime: false };
+  if (!q.config) q.config = { showDate: true, showTime: true };
   const cfg = q.config;
   if (cfg.showDate === undefined) cfg.showDate = true;
-  if (cfg.showTime === undefined) cfg.showTime = false;
+  if (cfg.showTime === undefined) cfg.showTime = true;
 
   const section = el('section', { class: 'px-5 pb-5 space-y-4 border-t border-gray-100 pt-4' });
   const hdr = el('div', { class: 'flex items-center justify-between gap-2' });
@@ -2485,7 +2485,7 @@ function buildPreviewData() {
 
     if (q.type === 'date_time') {
       const showDate = cfg.showDate !== false;
-      const showTime = cfg.showTime === true;
+      const showTime = cfg.showTime !== false;
       base.meta = {
         ...base.meta,
         dateTimeConfig: {
@@ -2765,9 +2765,9 @@ async function loadSurveyData(surveyId) {
         base.matrixCols = (q.options || []).map(c => ({ ja: c.text || '' }));
       }
       if (type === 'date_time') {
-        // 保存済みの入力モードから日付/時刻トグルを復元（無ければ旧typeで判定、既定は日付のみ）
+        // 保存済みの入力モードから日付/時刻トグルを復元（無ければ旧typeで判定、既定は日付・時刻の両方）
         const mode = q.meta?.dateTimeConfig?.inputMode || q.inputMode
-          || (q.type === 'time' ? 'time' : q.type === 'date' ? 'date' : 'date');
+          || (q.type === 'time' ? 'time' : q.type === 'date' ? 'date' : 'datetime');
         base.config = mode === 'datetime' ? { showDate: true, showTime: true }
           : mode === 'time' ? { showDate: false, showTime: true }
           : { showDate: true, showTime: false };


### PR DESCRIPTION
## 概要
新規追加した日付/時間設問の既定を「日付のみ」→「日付・時刻の両方オン」に変更（02_dashboard／05_support/tutorial 両方）。

## 変更内容
- 新規作成時のデフォルト config を `{ showDate: true, showTime: true }` に
- 編集UIの config 未定義フォールバックも両方オンに
- 保存時の showTime 判定を `=== true` → `!== false` に対称化
- 読込時に inputMode 未保存の date_time 設問の既定を datetime に

## 影響範囲
保存済みの日付のみ/時刻のみ設問は meta.dateTimeConfig.inputMode または旧type（date/time）から復元されるため挙動変更なし。

## 検証
- node --check 両ファイル通過
- Playwright 実画面操作: FABメニューから日付/時間設問を追加 → 日付・時刻トグルとも初期ON（aria-checked=true）、ページエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)