### PR TITLE
feat(survey): 言語タブをソケット型デザインに刷新

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -2838,14 +2838,15 @@ body.dark-mode .outline-highlight {
     white-space: nowrap;
 }
 
-/* Chrome-like Lang Tabs */
+/* Chrome-like Lang Tabs — サンクス画面設定（thankYouScreenSettings）の言語切替タブで使用。
+   アンケート編集画面のタブはソケット型（.lang-tabbar / .lang-chip）へ移行済み。 */
 .lang-tab {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 0.375rem;
     padding: 0.625rem 0.75rem 0.625rem 1rem;
-    cursor: grab;
+    cursor: pointer;
     -webkit-user-select: none;
     user-select: none;
     transition: background-color 0.2s, color 0.2s;
@@ -2865,7 +2866,6 @@ body.dark-mode .outline-highlight {
     margin-left: auto;
     flex-shrink: 0;
 }
-.lang-tab:active { cursor: grabbing; }
 .lang-tab:hover:not(.active) {
     background-color: #e5e7eb;
     color: #374151;
@@ -2885,6 +2885,201 @@ body.dark-mode .outline-highlight {
     right: 0;
     height: 1px;
     background-color: #e5e7eb;
+}
+
+/* ===== Language Tab Bar (socket design) =====
+   第一言語は左端の「ソケット」に収まり、その他言語は仕切りの右に並ぶ。
+   ネイティブ HTML5 D&D で第一言語の入れ替え・並べ替えができる。 */
+.lang-tabbar {
+    width: 100%;
+    background: #ffffff;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 0.75rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+}
+.lang-tabbar__row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px;
+    flex-wrap: nowrap;
+    min-width: 0;
+}
+.lang-tabbar__underline {
+    height: 3px;
+    background: linear-gradient(90deg, #1e40af, #3b82f6 55%, #60a5fa);
+}
+
+/* ソケット（第一言語の枠） */
+.lang-socket {
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 7px;
+    background: #e4ebf7;
+    border-radius: 12px;
+    box-shadow: inset 0 2px 5px rgba(15, 23, 42, 0.15);
+}
+.lang-socket__label {
+    position: absolute;
+    top: -9px;
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
+    z-index: 7;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: #ffffff;            /* on #2563eb ≈ 5.2:1 */
+    background: #2563eb;
+    padding: 2px 9px;
+    border-radius: 999px;
+}
+/* ドラッグ中のみ出現するドロップ受け（第一言語化） */
+.lang-socket__overlay {
+    position: absolute;
+    inset: -3px;
+    border-radius: 14px;
+    z-index: 6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s;
+    border: 2px dashed #6f97ee;
+    background: rgba(239, 246, 255, 0.94);
+}
+.lang-socket__overlay.is-active { opacity: 1; pointer-events: auto; }
+.lang-socket__overlay.is-hover {
+    border-color: #1d4ed8;
+    background: rgba(191, 219, 254, 0.94);
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+.lang-socket__overlay span {
+    font-size: 11.5px;
+    font-weight: 700;
+    color: #1d4ed8;
+    text-align: center;
+    line-height: 1.3;
+    padding: 0 8px;
+    pointer-events: none;
+}
+
+/* チップ（言語タブ） */
+.lang-chip {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+    padding: 9px 14px 9px 10px;
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 9px;
+    cursor: grab;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    -webkit-user-select: none;
+    user-select: none;
+    font: inherit;
+    white-space: nowrap;
+    outline: none;
+}
+/* フォーカスリング（WCAG 1.4.11: 白2pxの間隔＋不透明 #1d4ed8 4px。
+   白背景で約5.9:1、ソケット #e4ebf7 でも 3:1 以上を確保） */
+.lang-chip:focus-visible { box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #1d4ed8; }
+.lang-chip[draggable="false"] { cursor: default; }
+.lang-chip:active { cursor: grabbing; }
+.lang-chip--primary {
+    border-color: #cfd9ea;
+    box-shadow: 0 2px 5px rgba(15, 23, 42, 0.12);
+}
+/* 編集中（アクティブ）の言語をどのチップでも示す控えめな強調 */
+.lang-chip.active {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+}
+.lang-chip__grip {
+    display: inline-flex;
+    flex: none;
+    color: #b7c0cd;
+}
+.lang-chip__name {
+    font-size: 13.5px;
+    font-weight: 600;
+    color: #374151;
+    white-space: nowrap;
+}
+.lang-chip--primary .lang-chip__name { font-weight: 700; color: #111827; }
+.lang-chip.active .lang-chip__name { color: #1d4ed8; }
+/* 未入力バッジ（WCAG 1.4.3: #b91c1c on #fde8e8 で約5.9:1） */
+.lang-chip__badge {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 700;
+    color: #b91c1c;
+    background: #fde8e8;
+    padding: 2px 8px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+/* ドロップ受けリング（センサー＋ハイライト） */
+.lang-chip__ring {
+    position: absolute;
+    inset: -2px;
+    border-radius: 11px;
+    z-index: 4;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s;
+    border: 2px dashed #b6c2d4;
+}
+.lang-chip__ring.is-sensor { pointer-events: auto; }
+.lang-chip__ring.is-src { opacity: 1; background: rgba(248, 250, 252, 0.72); }
+.lang-chip__ring.is-over {
+    opacity: 1;
+    border: 2px solid #2563eb;
+    background: rgba(37, 99, 235, 0.09);
+}
+
+.lang-divider {
+    width: 1px;
+    align-self: stretch;
+    flex-shrink: 0;
+    background: #e5e7eb;
+}
+.lang-others {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding: 3px 2px;   /* アクティブ/ドロップ受けリング(2px)がスクロールでクリップされないための余白 */
+}
+.lang-others::-webkit-scrollbar { display: none; }
+/* WCAG 1.4.3: ヒント文字 #5b6472（白背景で約5.8:1、マージン確保） */
+.lang-hint {
+    margin-left: auto;
+    flex-shrink: 0;
+    font-size: 11.5px;
+    color: #5b6472;
+    white-space: nowrap;
+    -webkit-user-select: none;
+    user-select: none;
+}
+/* レスポンシブ: 狭い幅ではヒントを隠し、その他言語だけ横スクロールさせる（縦書き化を防ぐ） */
+@media (max-width: 900px) {
+    .lang-hint { display: none; }
+    .lang-tabbar__row { gap: 10px; padding: 14px; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .lang-socket__overlay,
+    .lang-chip__ring { transition: none; }
 }
 
 /* 第一言語参照ヒント (多言語モード時、第二・第三言語入力欄の下に表示) */

--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -187,9 +187,12 @@ let currentLangs = ['ja'];
 let activeLang = 'ja';
 let isReadOnlyMode = false;
 
+// 言語タブのドラッグ&ドロップ状態（ネイティブ HTML5 D&D。設問/選択肢の SortableJS とは独立）
+let langDragId = null;  // ドラッグ中の言語コード
+let langOverId = null;  // ドロップ受けでホバー中のターゲット（'slot' または 言語コード）
+
 let sortables = {
   questions: null,
-  langTabs: null,
   outline: null,
   options: {}
 };
@@ -314,12 +317,62 @@ function ensureMultiLangInputExists(group, lang) {
   group.appendChild(div);
 }
 
+// 言語タブの切替（クリック・キーボード操作の共通処理。roving tabindex の単一情報源）
+function activateLangTab(langCode) {
+  activeLang = langCode;
+  updateMultiLangVisibility();
+  updateOutline();
+}
+
+// WAI-ARIA APG Tabs パターン（automatic activation）: 左右矢印でフォーカス移動＋即時切替、Enter/Spaceでも切替
+function handleLangTabKeydown(e, langCode) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    activateLangTab(langCode);
+    return;
+  }
+
+  // Ctrl/Cmd + 左右矢印: フォーカス中の言語を並べ替える（ドラッグの代替。先頭へ動かせば第一言語になる）
+  if ((e.ctrlKey || e.metaKey) && (e.key === 'ArrowRight' || e.key === 'ArrowLeft')) {
+    e.preventDefault();
+    const from = currentLangs.indexOf(langCode);
+    if (from === -1 || currentLangs.length <= 1) return;
+    const to = e.key === 'ArrowLeft' ? from - 1 : from + 1;
+    if (to < 0 || to >= currentLangs.length) return;
+
+    const prevFirst = currentLangs[0];
+    currentLangs.splice(from, 1);
+    currentLangs.splice(to, 0, langCode);
+    finishLangReorder(prevFirst);
+
+    // 再描画で作り直されたチップにフォーカスを戻す
+    const moved = document.querySelector(`#languageEditorTabsV2 .lang-chip[data-lang="${langCode}"]`);
+    if (moved) moved.focus();
+    return;
+  }
+
+  if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+
+  const tabs = Array.from(document.querySelectorAll('#languageEditorTabsV2 .lang-chip'));
+  const idx = tabs.findIndex(t => t.dataset.lang === langCode);
+  if (idx === -1 || tabs.length <= 1) return;
+
+  e.preventDefault();
+  const nextIdx = e.key === 'ArrowRight' ? (idx + 1) % tabs.length : (idx - 1 + tabs.length) % tabs.length;
+  const nextTab = tabs[nextIdx];
+  activateLangTab(nextTab.dataset.lang);
+  nextTab.focus();
+}
+
 function updateMultiLangVisibility() {
-  // 単語タブのスタイル更新
-  document.querySelectorAll('.lang-tab').forEach(tab => {
-    tab.classList.toggle('active', tab.dataset.lang === activeLang);
+  // 言語タブのスタイル更新（roving tabindex: activeLang のチップのみ tabindex="0"）
+  document.querySelectorAll('.lang-chip').forEach(tab => {
+    const isActive = tab.dataset.lang === activeLang;
+    tab.classList.toggle('active', isActive);
+    tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    tab.setAttribute('tabindex', isActive ? '0' : '-1');
   });
-  
+
   // input-groupの表示切り替え
   document.querySelectorAll('.multi-lang-input-group').forEach(group => {
     group.querySelectorAll('[data-lang]').forEach(langDiv => {
@@ -383,29 +436,48 @@ function renderLangSelectionAndTabs() {
     panel.appendChild(btn);
   });
 
-  // タブ
+  // 言語タブ帯（ソケット型デザイン）を組み立てる。
+  // 第一言語は左端の「ソケット」に収まり、その他言語は仕切りの右側に並ぶ。
+  // 言語が1つだけの時は並べ替え不能なので、仕切り・その他・ヒント・ドラッグを無効化する。
+  const canReorder = currentLangs.length > 1;
+
+  tabsContainer.className = 'lang-tabbar__row';
+  tabsContainer.setAttribute('role', 'tablist');
   tabsContainer.innerHTML = '';
-  currentLangs.forEach(langCode => {
-    const langObj = SUPPORTED_LANGS.find(l => l.code === langCode);
-    const tab = el('div', {
-      class: `lang-tab ${langCode === activeLang ? 'active' : ''}`,
-      'data-lang': langCode,
-      onclick: () => {
-        activeLang = langCode;
-        updateMultiLangVisibility();
-        updateOutline();
-      }
-    });
 
-    const iconSpan = el('span', { class: 'material-icons text-[16px] opacity-70' }, 'translate');
-    const txt = el('span', { class: 'truncate font-medium' }, langObj ? langObj.name : langCode);
+  // ソケット（第一言語の枠）。role="presentation" で tablist の直下は tab のみが意味を持つようにする
+  const socket = el('div', { class: 'lang-socket', role: 'presentation' });
+  socket.appendChild(el('span', { class: 'lang-socket__label', 'aria-hidden': 'true' }, '第一言語'));
+  socket.appendChild(makeLangChip(currentLangs[0], true, canReorder));
 
-    tab.append(iconSpan, txt);
-    tabsContainer.appendChild(tab);
+  // ドラッグ中のみ出現するドロップ受け（第一言語化）
+  const overlay = el('div', { class: 'lang-socket__overlay', 'aria-hidden': 'true' },
+    el('span', {}, 'ここにドロップ'));
+  overlay.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    try { e.dataTransfer.dropEffect = 'move'; } catch (_) {}
+    if (langOverId !== 'slot') { langOverId = 'slot'; updateLangDnd(); }
   });
+  overlay.addEventListener('dragleave', () => { if (langOverId === 'slot') { langOverId = null; updateLangDnd(); } });
+  overlay.addEventListener('drop', (e) => { e.preventDefault(); if (langDragId) promoteLang(langDragId); });
+  socket.appendChild(overlay);
+  tabsContainer.appendChild(socket);
 
-  initLangTabsSortable();
-  onLangsChanged(); 
+  // 仕切り + その他言語 + ヒント（ラッパは role="presentation"、tab の意味は各チップに閉じる）
+  const divider = el('div', { class: 'lang-divider', 'aria-hidden': 'true' });
+  const others = el('div', { class: 'lang-others', role: 'presentation' });
+  currentLangs.slice(1).forEach(code => others.appendChild(makeLangChip(code, false, canReorder)));
+  const hint = el('div', { class: 'lang-hint', role: 'presentation' }, '枠へドラッグで第一言語に');
+  if (!canReorder) {
+    // インライン display:none で確実に隠す（.lang-* の display 宣言に負けないため）
+    divider.style.display = 'none';
+    others.style.display = 'none';
+    hint.style.display = 'none';
+  }
+  tabsContainer.append(divider, others, hint);
+
+  updateLangDnd();
+  onLangsChanged();
 }
 
 function onLangsChanged() {
@@ -419,20 +491,131 @@ function onLangsChanged() {
   updateMultiLangVisibility();
 }
 
-function initLangTabsSortable() {
-  const container = document.getElementById('languageEditorTabsV2');
-  if (!container || typeof Sortable === 'undefined') return;
-  
-  if (sortables.langTabs) sortables.langTabs.destroy();
-  sortables.langTabs = new Sortable(container, {
-    handle: '.lang-tab',
-    animation: 150,
-    group: 'language-tabs',
-    onEnd: () => {
-      const newOrder = [];
-      container.querySelectorAll('.lang-tab').forEach(t => newOrder.push(t.dataset.lang));
-      currentLangs = newOrder;
-    }
+// ドラッグハンドルの6ドット SVG（静的文字列。currentColor で CSS 側から色制御）
+function langGripSvg() {
+  const dots = ['2.2,2.6', '6.8,2.6', '2.2,7.5', '6.8,7.5', '2.2,12.4', '6.8,12.4']
+    .map(p => { const [x, y] = p.split(','); return `<circle cx="${x}" cy="${y}" r="1.35" fill="currentColor"/>`; })
+    .join('');
+  return `<svg width="9" height="15" viewBox="0 0 9 15" aria-hidden="true" focusable="false">${dots}</svg>`;
+}
+
+// 言語タブ（チップ）を生成する。isPrimary=ソケット内の第一言語タブ、canReorder=D&D有効
+function makeLangChip(langCode, isPrimary, canReorder) {
+  const langObj = SUPPORTED_LANGS.find(l => l.code === langCode);
+  const langName = langObj ? langObj.name : langCode;
+  const isActive = langCode === activeLang;
+
+  // aria-label はチップ内の全テキストを上書きするため、後から付く「未入力 N」バッジは
+  // updateTranslationBadges() がこの基本ラベルに件数を連結して同期する
+  const baseLabel = isPrimary ? `${langName}（第一言語）` : langName;
+  const title = canReorder
+    ? 'クリック/Enter/Spaceで切替、矢印キーで移動、Ctrl+矢印またはドラッグで並べ替え'
+    : 'クリックまたはEnter/Spaceで切替、矢印キーで移動';
+
+  const chip = el('div', {
+    class: `lang-chip${isPrimary ? ' lang-chip--primary' : ''}${isActive ? ' active' : ''}`,
+    'data-lang': langCode,
+    role: 'tab',
+    'aria-selected': isActive ? 'true' : 'false',
+    tabindex: isActive ? '0' : '-1',
+    title,
+    'aria-label': baseLabel,
+    'data-base-label': baseLabel,
+    onclick: () => activateLangTab(langCode),
+    onkeydown: (e) => handleLangTabKeydown(e, langCode)
+  });
+  chip.draggable = canReorder;
+
+  if (canReorder) {
+    const grip = el('span', { class: 'lang-chip__grip', 'aria-hidden': 'true' });
+    grip.innerHTML = langGripSvg();
+    chip.appendChild(grip);
+  }
+  chip.appendChild(el('span', { class: 'lang-chip__name' }, langName));
+  chip.appendChild(el('div', { class: 'lang-chip__ring', 'aria-hidden': 'true' }));
+
+  if (canReorder) attachLangChipDnd(chip, langCode);
+  return chip;
+}
+
+// チップにネイティブ D&D リスナーを取り付ける（リング要素がドロップ受けのセンサー）
+function attachLangChipDnd(chip, langCode) {
+  chip.addEventListener('dragstart', (e) => {
+    try { e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', langCode); } catch (_) {}
+    // 直後に DOM を書き換えるとドラッグが中断するため 1 tick 遅延させる
+    setTimeout(() => { langDragId = langCode; updateLangDnd(); }, 0);
+  });
+  chip.addEventListener('dragend', () => { langDragId = langOverId = null; updateLangDnd(); });
+
+  const ring = chip.querySelector('.lang-chip__ring');
+  ring.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    try { e.dataTransfer.dropEffect = 'move'; } catch (_) {}
+    if (langOverId !== langCode) { langOverId = langCode; updateLangDnd(); }
+  });
+  ring.addEventListener('dragleave', () => { if (langOverId === langCode && ring.isConnected) { langOverId = null; updateLangDnd(); } });
+  ring.addEventListener('drop', (e) => { e.preventDefault(); dropLangOnChip(langCode); });
+}
+
+// 第一言語にする（ソケット/第一言語チップへのドロップ）: 対象と第一言語の位置を交換
+function promoteLang(id) {
+  const prevFirst = currentLangs[0];
+  const fi = currentLangs.indexOf(id);
+  if (fi > 0) { currentLangs[0] = id; currentLangs[fi] = prevFirst; }
+  finishLangReorder(prevFirst);
+}
+
+// チップ上へのドロップ（並べ替え/交換）
+function dropLangOnChip(targetId) {
+  const dragId = langDragId;
+  if (!dragId || dragId === targetId) { langDragId = langOverId = null; updateLangDnd(); return; }
+  const prevFirst = currentLangs[0];
+  const fi = currentLangs.indexOf(dragId), ti = currentLangs.indexOf(targetId);
+  if (ti === 0) { promoteLang(dragId); return; }        // 第一言語チップに重ねた → 第一言語化(交換)
+  if (fi === 0) {                                        // 第一言語を他チップへ → 位置交換
+    const old = currentLangs[0]; currentLangs[0] = currentLangs[ti]; currentLangs[ti] = old;
+  } else {                                               // 他チップ同士 → 挿入並べ替え
+    currentLangs.splice(fi, 1);
+    const nt = currentLangs.indexOf(targetId);
+    currentLangs.splice(fi < ti ? nt + 1 : nt, 0, dragId);
+  }
+  finishLangReorder(prevFirst);
+}
+
+// 並べ替え確定後の共通処理: 全体再描画 + アウトライン更新 + 第一言語変更トースト
+function finishLangReorder(prevFirstLang) {
+  langDragId = langOverId = null;
+  if (!currentLangs.includes(activeLang)) activeLang = currentLangs[0];
+
+  // 第一言語に依存する参照ヒント・未翻訳バッジ・アウトラインを含めて全体再描画する
+  renderLangSelectionAndTabs();
+  updateOutline();
+
+  const newFirstLang = currentLangs[0];
+  if (prevFirstLang != null && newFirstLang !== prevFirstLang) {
+    const langObj = SUPPORTED_LANGS.find(l => l.code === newFirstLang);
+    showToast(`第一言語を${langObj ? langObj.name : newFirstLang}に変更しました`, 'success');
+  }
+}
+
+// ドラッグ状態の見た目更新（ソケットのドロップ受け・各チップのリング）
+function updateLangDnd() {
+  const row = document.getElementById('languageEditorTabsV2');
+  if (!row) return;
+  const draggingNonPrimary = !!langDragId && currentLangs.indexOf(langDragId) > 0;
+
+  const overlay = row.querySelector('.lang-socket__overlay');
+  if (overlay) {
+    overlay.classList.toggle('is-active', draggingNonPrimary);
+    overlay.classList.toggle('is-hover', draggingNonPrimary && langOverId === 'slot');
+  }
+  row.querySelectorAll('.lang-chip').forEach(chip => {
+    const id = chip.dataset.lang;
+    const ring = chip.querySelector('.lang-chip__ring');
+    if (!ring) return;
+    ring.classList.toggle('is-sensor', !!langDragId && langDragId !== id);
+    ring.classList.toggle('is-src', langDragId === id);
+    ring.classList.toggle('is-over', langOverId === id && langDragId !== id);
   });
 }
 
@@ -448,9 +631,7 @@ function initMultilingualToggle() {
     if (mainTabs) {
       mainTabs.style.visibility = toggle.checked ? 'visible' : 'hidden';
     }
-    const basicInfoBody = document.getElementById('basicInfoBody');
-    basicInfoBody?.classList.toggle('rounded-tl-none', toggle.checked);
-    basicInfoBody?.classList.toggle('rounded-tr-none', toggle.checked);
+    // 新しいタブ帯は独立したカードなので、基本情報カードの角丸を潰す必要はない
     document.body.classList.toggle('has-multi-lang-tabs', toggle.checked);
 
     if(!isMultilingual) {
@@ -824,20 +1005,27 @@ function updateTranslationBadges() {
   if (!isMultilingual) return;
   const extraLangs = currentLangs.slice(1); // 第一言語(ja)以外
 
-  // 言語タブのバッジ
-  document.querySelectorAll('#languageEditorTabsV2 .lang-tab[data-lang]').forEach(tab => {
+  // 言語タブ（チップ）の未入力バッジ。第一言語は対象外
+  document.querySelectorAll('#languageEditorTabsV2 .lang-chip[data-lang]').forEach(tab => {
     const lang = tab.dataset.lang;
     if (lang === currentLangs[0]) return;
     const count = countMissingForLang(lang);
-    let badge = tab.querySelector('.translation-progress-badge');
+    let badge = tab.querySelector('.lang-chip__badge');
+    // aria-label がチップ内テキストを上書きするため、バッジの件数はラベル側にも反映する
+    const baseLabel = tab.dataset.baseLabel || tab.getAttribute('aria-label') || '';
     if (count > 0) {
       if (!badge) {
-        badge = el('span', { class: 'translation-progress-badge' });
-        tab.appendChild(badge);
+        // 件数は aria-label にも連結済みのため、視覚バッジ自体は aria-hidden で読み上げ重複を防ぐ
+        badge = el('span', { class: 'lang-chip__badge', 'aria-hidden': 'true' });
+        // リング（絶対配置のドロップ受け）の前に挿入して名前の直後に並べる
+        const ring = tab.querySelector('.lang-chip__ring');
+        if (ring) tab.insertBefore(badge, ring); else tab.appendChild(badge);
       }
       badge.textContent = `未入力 ${count}`;
-    } else if (badge) {
-      badge.remove();
+      tab.setAttribute('aria-label', `${baseLabel}、未入力 ${count}件`);
+    } else {
+      if (badge) badge.remove();
+      tab.setAttribute('aria-label', baseLabel);
     }
   });
 

--- a/02_dashboard/surveyCreation-v2.html
+++ b/02_dashboard/surveyCreation-v2.html
@@ -229,52 +229,7 @@
     .v2-toast--warning { background: #fef3c7; color: #92400e; }
     .v2-toast--info    { background: #dbeafe; color: #1e40af; }
 
-    /* Chrome-like Lang Tabs */
-    .lang-tab {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.375rem;
-      padding: 0.625rem 0.75rem 0.625rem 1rem;
-      cursor: grab;
-      -webkit-user-select: none;
-      user-select: none;
-      transition: background-color 0.2s, color 0.2s;
-      border-radius: 0.75rem 0.75rem 0 0;
-      border: 1px solid transparent;
-      border-bottom: none;
-      position: relative;
-      margin-bottom: -1px; /* Overlap border */
-      z-index: 10;
-      color: #6b7280;
-      min-width: 110px;
-      font-size: 0.875rem;
-    }
-    .lang-tab .translation-progress-badge {
-      margin-left: auto;
-      flex-shrink: 0;
-    }
-    .lang-tab:active { cursor: grabbing; }
-    .lang-tab:hover:not(.active) {
-      background-color: #e5e7eb;
-      color: #374151;
-    }
-    .lang-tab.active {
-      background-color: #ffffff;
-      border-color: #e5e7eb;
-      color: var(--color-primary);
-      font-weight: 700;
-      z-index: 20;
-    }
-    .lang-tab:not(.active)::after {
-      content: '';
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      height: 1px;
-      background-color: #e5e7eb;
-    }
+    /* 言語タブ帯（ソケットデザイン）のスタイルは service-top-style.css に定義（.lang-tabbar / .lang-chip 等） */
 
     /* 第一言語参照ヒント (多言語モード時、第二・第三言語入力欄の下に表示) */
     .ref-lang-hint {
@@ -378,13 +333,12 @@
 
           <!-- STICKY GLOBAL TABS LIFTED OUT OF GRID -->
           <div id="mainAreaMultilingualTabs" class="sticky top-16 z-40 pt-2 pb-0 w-full bg-gray-50" style="transition: width 0.25s ease, margin-left 0.25s ease; visibility: hidden;">
-            <div class="bg-gray-100 pt-2 px-2 pb-[1px] flex items-end gap-1 rounded-t-xl border-x border-t border-gray-200 max-w-full overflow-hidden relative">
-              <div id="languageEditorTabsV2" class="flex items-end gap-1 w-full overflow-x-auto relative z-10" style="scrollbar-width: none;" role="tablist">
+            <div class="lang-tabbar">
+              <div id="languageEditorTabsV2" class="lang-tabbar__row" role="tablist">
                 <!-- Rendered by JS -->
               </div>
+              <div class="lang-tabbar__underline" aria-hidden="true"></div>
             </div>
-            <!-- The active tab overlaps this line -->
-            <div class="h-[3px] w-full bg-gradient-to-r from-blue-500 via-indigo-400 to-primary rounded-b-sm shadow-[0_2px_10px_rgba(99,102,241,0.2)] relative z-0"></div>
           </div>
 
           <!-- 3-AREA GRID CONTAINER -->
@@ -824,6 +778,9 @@
       </div>
     </div>
   </div>
+
+  <!-- Toast container (showToast の描画先。スタイルは #toast-container / .v2-toast を参照) -->
+  <div id="toast-container" aria-live="polite" aria-atomic="true"></div>
 
   <!-- External JS Module -->
   <script type="module" src="src/surveyCreation-v2.js"></script>

--- a/02_dashboard/surveyCreation.html
+++ b/02_dashboard/surveyCreation.html
@@ -229,52 +229,7 @@
     .v2-toast--warning { background: #fef3c7; color: #92400e; }
     .v2-toast--info    { background: #dbeafe; color: #1e40af; }
 
-    /* Chrome-like Lang Tabs */
-    .lang-tab {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.375rem;
-      padding: 0.625rem 0.75rem 0.625rem 1rem;
-      cursor: grab;
-      -webkit-user-select: none;
-      user-select: none;
-      transition: background-color 0.2s, color 0.2s;
-      border-radius: 0.75rem 0.75rem 0 0;
-      border: 1px solid transparent;
-      border-bottom: none;
-      position: relative;
-      margin-bottom: -1px; /* Overlap border */
-      z-index: 10;
-      color: #6b7280;
-      min-width: 110px;
-      font-size: 0.875rem;
-    }
-    .lang-tab .translation-progress-badge {
-      margin-left: auto;
-      flex-shrink: 0;
-    }
-    .lang-tab:active { cursor: grabbing; }
-    .lang-tab:hover:not(.active) {
-      background-color: #e5e7eb;
-      color: #374151;
-    }
-    .lang-tab.active {
-      background-color: #ffffff;
-      border-color: #e5e7eb;
-      color: var(--color-primary);
-      font-weight: 700;
-      z-index: 20;
-    }
-    .lang-tab:not(.active)::after {
-      content: '';
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      height: 1px;
-      background-color: #e5e7eb;
-    }
+    /* 言語タブ帯（ソケットデザイン）のスタイルは service-top-style.css に定義（.lang-tabbar / .lang-chip 等） */
 
     /* 第一言語参照ヒント (多言語モード時、第二・第三言語入力欄の下に表示) */
     .ref-lang-hint {
@@ -378,13 +333,12 @@
 
           <!-- STICKY GLOBAL TABS LIFTED OUT OF GRID -->
           <div id="mainAreaMultilingualTabs" class="sticky top-16 z-40 pt-2 pb-0 w-full bg-gray-50" style="transition: width 0.25s ease, margin-left 0.25s ease; visibility: hidden;">
-            <div class="bg-gray-100 pt-2 px-2 pb-[1px] flex items-end gap-1 rounded-t-xl border-x border-t border-gray-200 max-w-full overflow-hidden relative">
-              <div id="languageEditorTabsV2" class="flex items-end gap-1 w-full overflow-x-auto relative z-10" style="scrollbar-width: none;" role="tablist">
+            <div class="lang-tabbar">
+              <div id="languageEditorTabsV2" class="lang-tabbar__row" role="tablist">
                 <!-- Rendered by JS -->
               </div>
+              <div class="lang-tabbar__underline" aria-hidden="true"></div>
             </div>
-            <!-- The active tab overlaps this line -->
-            <div class="h-[3px] w-full bg-gradient-to-r from-blue-500 via-indigo-400 to-primary rounded-b-sm shadow-[0_2px_10px_rgba(99,102,241,0.2)] relative z-0"></div>
           </div>
 
           <!-- 3-AREA GRID CONTAINER -->


### PR DESCRIPTION
## 概要
アンケート編集画面（surveyCreation）の多言語タブを ClaudeDesign の「第一言語切り替え案」に置き換えました。第一言語が左端のソケットに収まることを視覚的に示し、ドラッグ＆ドロップ／キーボードで第一言語の入れ替えができます。

## 主な変更
- **ソケット型UIへ全面置換**: 「第一言語」ラベル付きソケット＋その他言語チップ＋ヒント＋青グラデ下線
- **SortableJS廃止→ネイティブHTML5 D&D**: ソケットへドロップで第一言語化（swap）、他タブ同士で並べ替え
- **キーボード完全対応**: 矢印で言語切替、Ctrl/Cmd+矢印で並べ替え（ドラッグの代替）
- **レスポンシブ**: 狭幅で縦書き化しないよう横スクロール化、≤900pxでヒント非表示（1024/768px検証済み）
- **機能維持**: aria-labelへの未入力件数連結、トースト、sticky追従、1言語時の簡略表示
- **共有CSS回帰の修正**: 削除した `.lang-tab` をサンクス画面設定（thankYouScreenSettings）向けに復元

## 品質ゲート
- コードレビュー（品質/セキュリティ/性能）: 承認
- アクセシビリティ監査 WCAG 2.1 AA: 承認（フォーカスリング5.6〜6.7:1、コントラスト/role/aria整備）
- 実画面E2E（Playwright・実クリック/実ドラッグ/実キー）: 全PASS・コンソールエラー0件

## 対象ファイル
- `02_dashboard/src/surveyCreation-v2.js`
- `02_dashboard/service-top-style.css`
- `02_dashboard/surveyCreation.html`
- `02_dashboard/surveyCreation-v2.html`

## 残課題（スコープ外）
- ダークモード時のコントラストは未確認（ライトモードは基準クリア）
- `05_support/tutorial/` フォークは未反映（反映するなら手動同期が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)