### PR TITLE
fix(survey): 言語タブの並べ替えヒント文言を削除

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -3062,19 +3062,8 @@ body.dark-mode .outline-highlight {
     padding: 3px 2px;   /* アクティブ/ドロップ受けリング(2px)がスクロールでクリップされないための余白 */
 }
 .lang-others::-webkit-scrollbar { display: none; }
-/* WCAG 1.4.3: ヒント文字 #5b6472（白背景で約5.8:1、マージン確保） */
-.lang-hint {
-    margin-left: auto;
-    flex-shrink: 0;
-    font-size: 11.5px;
-    color: #5b6472;
-    white-space: nowrap;
-    -webkit-user-select: none;
-    user-select: none;
-}
-/* レスポンシブ: 狭い幅ではヒントを隠し、その他言語だけ横スクロールさせる（縦書き化を防ぐ） */
+/* レスポンシブ: 狭い幅では余白を詰めて、その他言語だけ横スクロールさせる（縦書き化を防ぐ） */
 @media (max-width: 900px) {
-    .lang-hint { display: none; }
     .lang-tabbar__row { gap: 10px; padding: 14px; }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -463,18 +463,16 @@ function renderLangSelectionAndTabs() {
   socket.appendChild(overlay);
   tabsContainer.appendChild(socket);
 
-  // 仕切り + その他言語 + ヒント（ラッパは role="presentation"、tab の意味は各チップに閉じる）
+  // 仕切り + その他言語（ラッパは role="presentation"、tab の意味は各チップに閉じる）
   const divider = el('div', { class: 'lang-divider', 'aria-hidden': 'true' });
   const others = el('div', { class: 'lang-others', role: 'presentation' });
   currentLangs.slice(1).forEach(code => others.appendChild(makeLangChip(code, false, canReorder)));
-  const hint = el('div', { class: 'lang-hint', role: 'presentation' }, '枠へドラッグで第一言語に');
   if (!canReorder) {
     // インライン display:none で確実に隠す（.lang-* の display 宣言に負けないため）
     divider.style.display = 'none';
     others.style.display = 'none';
-    hint.style.display = 'none';
   }
-  tabsContainer.append(divider, others, hint);
+  tabsContainer.append(divider, others);
 
   updateLangDnd();
   onLangsChanged();


### PR DESCRIPTION
## 概要
アンケート編集画面の言語タブから「枠へドラッグで第一言語に」の案内テキストを削除しました。

ソケットの「第一言語」ラベル・グリップアイコン・チップの `title` で操作が伝わるため、ヒント文言は冗長でした。未使用になった `.lang-hint` の CSS も撤去しています。

## 検証（Playwright・実操作）
- ヒント要素が描画されないこと（count=0）
- ソケットへのドラッグで第一言語化（swap）・トースト表示が維持されること
- レイアウト崩れ・コンソールエラーなし

## 対象ファイル
- `02_dashboard/src/surveyCreation-v2.js`
- `02_dashboard/service-top-style.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)