### PR TITLE
fix(survey): 言語タブのa11yロールとモバイルツールチップを修正

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -2971,6 +2971,12 @@ body.dark-mode .outline-highlight {
     padding: 0;
 }
 .lang-help:focus-visible { outline: 2px solid #1d4ed8; outline-offset: 2px; }
+/* タップ領域を約28pxに拡張（見た目は16pxのまま。タッチ操作の当てやすさ確保） */
+.lang-help::after {
+    content: '';
+    position: absolute;
+    inset: -6px;
+}
 /* 説明ツールチップ（下方向・クリックで開閉・Esc/外側クリックで閉じる） */
 .lang-tip {
     position: absolute;
@@ -2978,6 +2984,8 @@ body.dark-mode .outline-highlight {
     left: -14px;
     z-index: 50;
     width: 252px;
+    max-width: calc(100vw - 24px);   /* 狭い画面でビューポート外へはみ出さない */
+    box-sizing: border-box;
     padding: 10px 12px;
     background: #1f2937;       /* 白文字 ≈ 14.6:1 */
     color: #ffffff;

--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -366,10 +366,12 @@ function handleLangTabKeydown(e, langCode) {
 
 function updateMultiLangVisibility() {
   // 言語タブのスタイル更新（roving tabindex: activeLang のチップのみ tabindex="0"）
+  // 役割は role="group" 内のトグルボタン群。編集中の言語を aria-current で示す。
   document.querySelectorAll('.lang-chip').forEach(tab => {
     const isActive = tab.dataset.lang === activeLang;
     tab.classList.toggle('active', isActive);
-    tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    if (isActive) tab.setAttribute('aria-current', 'true');
+    else tab.removeAttribute('aria-current');
     tab.setAttribute('tabindex', isActive ? '0' : '-1');
   });
 
@@ -442,11 +444,14 @@ function renderLangSelectionAndTabs() {
   const canReorder = currentLangs.length > 1;
 
   tabsContainer.className = 'lang-tabbar__row';
-  tabsContainer.setAttribute('role', 'tablist');
+  // role="group": 編集言語の選択ボタン群＋「?」説明ボタンを束ねる。
+  // （tablist にすると tab 以外の子=「?」ボタンが混在しセマンティクス違反になるため group を採用）
+  tabsContainer.setAttribute('role', 'group');
+  tabsContainer.setAttribute('aria-label', '編集言語');
   tabsContainer.innerHTML = '';
 
-  // 第一言語の囲み枠。role="presentation" で tablist の直下は tab のみが意味を持つようにする
-  const fieldset = el('div', { class: 'lang-fieldset', role: 'presentation' });
+  // 第一言語の囲み枠
+  const fieldset = el('div', { class: 'lang-fieldset' });
 
   // 凡例（「第一言語」ラベル ＋ ? 説明ボタン ＋ クリック開閉ツールチップ）
   const legend = el('div', { class: 'lang-legend' });
@@ -480,9 +485,9 @@ function renderLangSelectionAndTabs() {
   fieldset.appendChild(overlay);
   tabsContainer.appendChild(fieldset);
 
-  // 仕切り + その他言語（ラッパは role="presentation"、tab の意味は各チップに閉じる）
+  // 仕切り + その他言語
   const divider = el('div', { class: 'lang-divider', 'aria-hidden': 'true' });
-  const others = el('div', { class: 'lang-others', role: 'presentation' });
+  const others = el('div', { class: 'lang-others' });
   currentLangs.slice(1).forEach(code => others.appendChild(makeLangChip(code, false, canReorder)));
   if (!canReorder) {
     // インライン display:none で確実に隠す（.lang-* の display 宣言に負けないため）
@@ -534,8 +539,7 @@ function makeLangChip(langCode, isPrimary, canReorder) {
   const chip = el('div', {
     class: `lang-chip${isPrimary ? ' lang-chip--primary' : ''}${isActive ? ' active' : ''}`,
     'data-lang': langCode,
-    role: 'tab',
-    'aria-selected': isActive ? 'true' : 'false',
+    role: 'button',
     tabindex: isActive ? '0' : '-1',
     title,
     'aria-label': baseLabel,
@@ -543,6 +547,7 @@ function makeLangChip(langCode, isPrimary, canReorder) {
     onclick: () => activateLangTab(langCode),
     onkeydown: (e) => handleLangTabKeydown(e, langCode)
   });
+  if (isActive) chip.setAttribute('aria-current', 'true');  // 編集中の言語
   chip.draggable = draggable;
 
   if (draggable) {

--- a/02_dashboard/surveyCreation-v2.html
+++ b/02_dashboard/surveyCreation-v2.html
@@ -334,7 +334,7 @@
           <!-- STICKY GLOBAL TABS LIFTED OUT OF GRID -->
           <div id="mainAreaMultilingualTabs" class="sticky top-16 z-40 pt-2 pb-0 w-full bg-gray-50" style="transition: width 0.25s ease, margin-left 0.25s ease; visibility: hidden;">
             <div class="lang-tabbar">
-              <div id="languageEditorTabsV2" class="lang-tabbar__row" role="tablist">
+              <div id="languageEditorTabsV2" class="lang-tabbar__row" role="group" aria-label="編集言語">
                 <!-- Rendered by JS -->
               </div>
               <div class="lang-tabbar__underline" aria-hidden="true"></div>

--- a/02_dashboard/surveyCreation.html
+++ b/02_dashboard/surveyCreation.html
@@ -334,7 +334,7 @@
           <!-- STICKY GLOBAL TABS LIFTED OUT OF GRID -->
           <div id="mainAreaMultilingualTabs" class="sticky top-16 z-40 pt-2 pb-0 w-full bg-gray-50" style="transition: width 0.25s ease, margin-left 0.25s ease; visibility: hidden;">
             <div class="lang-tabbar">
-              <div id="languageEditorTabsV2" class="lang-tabbar__row" role="tablist">
+              <div id="languageEditorTabsV2" class="lang-tabbar__row" role="group" aria-label="編集言語">
                 <!-- Rendered by JS -->
               </div>
               <div class="lang-tabbar__underline" aria-hidden="true"></div>


### PR DESCRIPTION
## 概要
Codex のストップレビューが指摘した2点（tablistセマンティクス／モバイルツールチップ）を修正しました。

## 修正内容
### 1. tablistセマンティクス違反の解消
`role="tablist"` の直下に「?」説明ボタン（非tab要素）が混在しており、ARIA仕様に反していました。
- コンテナ `#languageEditorTabsV2`: `role="tablist"` → `role="group"`（`aria-label="編集言語"`）
- 各言語チップ: `role="tab"` / `aria-selected` → `role="button"` / `aria-current`（編集中の言語を示す）
- これにより「?」ボタンが group 内に正しく収まる（group は任意のコントロールを内包可）

### 2. モバイルツールチップ
- 「?」のタップ領域を約28pxに拡張（見た目は16pxのまま、`::after` で当たり判定を拡大）
- ツールチップに `max-width: calc(100vw - 24px)` + `box-sizing: border-box` を付与し、狭い画面でのビューポート見切れを防止

## 検証（Playwright・実操作）
- デスクトップ: container=group / chip=button+aria-current、aria-selected・role=tab の残存0、矢印切替・Ctrl+矢印の並べ替え＋トースト・ツールチップ開閉/Esc — 全PASS
- モバイル360px（タッチ）: 「?」タップでツールチップ表示・ビューポート内（右端340≦360）・外側タップで閉じる — 全PASS
- コンソールエラー0件

## 対象ファイル
- `02_dashboard/src/surveyCreation-v2.js`
- `02_dashboard/service-top-style.css`
- `02_dashboard/surveyCreation.html`
- `02_dashboard/surveyCreation-v2.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)