### PR TITLE
refactor(survey): 第一言語ヘルプの「?」を多言語カード見出しへ移設

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -2946,12 +2946,6 @@ body.dark-mode .outline-highlight {
     letter-spacing: 0.02em;
     color: #1d4ed8;            /* on #fff ≈ 6.7:1 */
 }
-/* ? ボタン＋ツールチップのラッパ（ツールチップの位置基準） */
-.lang-help-wrap {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-}
 /* 「?」説明ボタン（クリック開閉。WCAG 1.4.11: 枠線 #2563eb ≈ 5.2:1） */
 .lang-help {
     position: relative;
@@ -2977,14 +2971,16 @@ body.dark-mode .outline-highlight {
     position: absolute;
     inset: -6px;
 }
-/* 説明ツールチップ（下方向・クリックで開閉・Esc/外側クリックで閉じる） */
+/* 説明ツールチップ。多言語カード見出しの「?」直下に position:fixed で配置する
+   （祖先の overflow:hidden にクリップされないよう位置は JS が計算）。
+   クリックで開閉・Esc/外側クリック/スクロールで閉じる */
 .lang-tip {
-    position: absolute;
-    top: calc(100% + 9px);
-    left: -14px;
-    z-index: 50;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 60;
     width: 252px;
-    max-width: calc(100vw - 24px);   /* 狭い画面でビューポート外へはみ出さない */
+    max-width: calc(100vw - 16px);   /* 狭い画面でビューポート外へはみ出さない */
     box-sizing: border-box;
     padding: 10px 12px;
     background: #1f2937;       /* 白文字 ≈ 14.6:1 */
@@ -2993,16 +2989,17 @@ body.dark-mode .outline-highlight {
     line-height: 1.65;
     font-weight: 500;
     text-align: left;
-    white-space: normal;       /* 親 .lang-legend の nowrap を打ち消し、252px 内で折り返す */
+    white-space: normal;
     border-radius: 8px;
     box-shadow: 0 6px 16px rgba(15, 23, 42, 0.25);
 }
 .lang-tip[hidden] { display: none; }
+/* 「?」ボタンを指す上向きの三角（水平位置は JS が --lang-tip-arrow-left で補正） */
 .lang-tip::before {
     content: '';
     position: absolute;
     top: -4px;
-    left: 17px;
+    left: var(--lang-tip-arrow-left, 20px);
     width: 9px;
     height: 9px;
     background: #1f2937;

--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -453,21 +453,10 @@ function renderLangSelectionAndTabs() {
   // 第一言語の囲み枠
   const fieldset = el('div', { class: 'lang-fieldset' });
 
-  // 凡例（「第一言語」ラベル ＋ ? 説明ボタン ＋ クリック開閉ツールチップ）
+  // 凡例（「第一言語」ラベルのみ。説明の「?」は多言語カードの見出し側に配置）
   const legend = el('div', { class: 'lang-legend' });
-  const helpWrap = el('span', { class: 'lang-help-wrap' });  // ツールチップの位置基準（? ボタンの直下に出す）
-  const helpBtn = el('button', {
-    id: 'langHelpBtn', class: 'lang-help', type: 'button',
-    'aria-expanded': 'false', 'aria-describedby': 'langPrimaryTip', 'aria-label': '第一言語について',
-    onclick: toggleLangTip
-  }, '?');
-  const tip = el('div', {
-    id: 'langPrimaryTip', class: 'lang-tip', role: 'tooltip', hidden: true
-  }, LANG_PRIMARY_TIP);
-  helpWrap.append(helpBtn, tip);
-  legend.append(el('span', { class: 'lang-legend__text' }, '第一言語'), helpWrap);
+  legend.append(el('span', { class: 'lang-legend__text' }, '第一言語'));
   fieldset.appendChild(legend);
-  ensureLangTipDismissers();
 
   // 第一言語チップ（枠の中・ドラッグ不可）
   fieldset.appendChild(makeLangChip(currentLangs[0], true, canReorder));
@@ -483,6 +472,7 @@ function renderLangSelectionAndTabs() {
   overlay.addEventListener('dragleave', () => { if (langOverId === 'slot') { langOverId = null; updateLangDnd(); } });
   overlay.addEventListener('drop', (e) => { e.preventDefault(); if (langDragId) promoteLang(langDragId); });
   fieldset.appendChild(overlay);
+
   tabsContainer.appendChild(fieldset);
 
   // 仕切り + その他言語
@@ -648,7 +638,6 @@ function updateLangDnd() {
 // ─────────────────────────────────────────
 // 第一言語の説明ツールチップ（? ボタンでクリック開閉・Esc/外側クリックで閉じる）
 // ─────────────────────────────────────────
-const LANG_PRIMARY_TIP = '回答画面で最初に表示される言語です。ほかの言語タブをこの枠へドラッグ、またはキーボードの Ctrl+左右キーで第一言語を入れ替えられます。';
 let langTipDismissersBound = false;
 
 function closeLangTip() {
@@ -656,6 +645,23 @@ function closeLangTip() {
   const btn = document.getElementById('langHelpBtn');
   if (tip) tip.hidden = true;
   if (btn) btn.setAttribute('aria-expanded', 'false');
+}
+
+// ツールチップは position:fixed。祖先の overflow:hidden にクリップされないよう
+// ビューポート基準でボタンの直下に配置する（開くたびに再計算）
+function positionLangTip() {
+  const tip = document.getElementById('langPrimaryTip');
+  const btn = document.getElementById('langHelpBtn');
+  if (!tip || !btn) return;
+  const r = btn.getBoundingClientRect();
+  tip.style.top = `${Math.round(r.bottom + 8)}px`;
+  const w = tip.offsetWidth || 252;
+  let left = r.left - 14;
+  left = Math.max(8, Math.min(left, window.innerWidth - w - 8));
+  tip.style.left = `${Math.round(left)}px`;
+  // 三角（::before）がボタンを指すよう、実際の左位置に応じて水平オフセットを補正
+  const arrowLeft = Math.max(10, Math.min(r.left + r.width / 2 - left - 4, w - 20));
+  tip.style.setProperty('--lang-tip-arrow-left', `${Math.round(arrowLeft)}px`);
 }
 
 function toggleLangTip(e) {
@@ -666,9 +672,10 @@ function toggleLangTip(e) {
   const willOpen = tip.hidden;
   tip.hidden = !willOpen;
   btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+  if (willOpen) positionLangTip();
 }
 
-// 外側クリック・Esc でツールチップを閉じるハンドラを一度だけ document に取り付ける
+// 外側クリック・Esc・スクロールでツールチップを閉じる/追従するハンドラを一度だけ取り付ける
 function ensureLangTipDismissers() {
   if (langTipDismissersBound) return;
   langTipDismissersBound = true;
@@ -683,6 +690,23 @@ function ensureLangTipDismissers() {
     const tip = document.getElementById('langPrimaryTip');
     if (tip && !tip.hidden) { closeLangTip(); document.getElementById('langHelpBtn')?.focus(); }
   });
+  // スクロール/リサイズ時は位置がずれるので閉じる（fixed 配置のため）
+  window.addEventListener('scroll', () => {
+    const tip = document.getElementById('langPrimaryTip');
+    if (tip && !tip.hidden) closeLangTip();
+  }, true);
+  window.addEventListener('resize', () => {
+    const tip = document.getElementById('langPrimaryTip');
+    if (tip && !tip.hidden) closeLangTip();
+  });
+}
+
+// 多言語カード見出しの「?」（静的HTML）にツールチップ開閉を配線する
+function initLangHelpTip() {
+  const btn = document.getElementById('langHelpBtn');
+  if (!btn) return;
+  btn.addEventListener('click', toggleLangTip);
+  ensureLangTipDismissers();
 }
 
 function initMultilingualToggle() {
@@ -3282,6 +3306,7 @@ async function init() {
 
   initMultilingualToggle();
   initLangTabWidthTracking();
+  initLangHelpTip();
   initFab();
   initInlineAddButton();
   initMobileAddButton();

--- a/02_dashboard/surveyCreation-v2.html
+++ b/02_dashboard/surveyCreation-v2.html
@@ -439,8 +439,9 @@
                   <!-- トグル -->
                   <div class="flex items-center justify-between gap-3">
                     <div class="min-w-0">
-                      <p class="font-bold text-sm text-amber-800 leading-tight">多言語機能を有効にする</p>
+                      <p class="font-bold text-sm text-amber-800 leading-tight flex items-center gap-1.5">多言語機能を有効にする<button id="langHelpBtn" class="lang-help" type="button" aria-expanded="false" aria-describedby="langPrimaryTip" aria-label="第一言語について">?</button></p>
                       <p class="text-xs text-amber-700/70 mt-0.5 leading-snug">複数言語でアンケートを提供します。</p>
+                      <div id="langPrimaryTip" class="lang-tip" role="tooltip" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
                     </div>
                     <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
                       <input type="checkbox" id="multilingualEnabledToggle" class="sr-only peer">

--- a/02_dashboard/surveyCreation.html
+++ b/02_dashboard/surveyCreation.html
@@ -527,8 +527,9 @@
                   <!-- トグル -->
                   <div class="flex items-center justify-between gap-3">
                     <div class="min-w-0">
-                      <p class="font-bold text-sm text-amber-800 leading-tight">多言語機能を有効にする</p>
+                      <p class="font-bold text-sm text-amber-800 leading-tight flex items-center gap-1.5">多言語機能を有効にする<button id="langHelpBtn" class="lang-help" type="button" aria-expanded="false" aria-describedby="langPrimaryTip" aria-label="第一言語について">?</button></p>
                       <p class="text-xs text-amber-700/70 mt-0.5 leading-snug">複数言語でアンケートを提供します。</p>
+                      <div id="langPrimaryTip" class="lang-tip" role="tooltip" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
                     </div>
                     <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
                       <input type="checkbox" id="multilingualEnabledToggle" class="sr-only peer">


### PR DESCRIPTION
## 概要
言語タブの「第一言語」ラベルに張り付いていた「?」説明ツールチップを、「多言語機能を有効にする」カード見出しの横へ移設しました。タブ帯からは「?」を外し、「第一言語」ラベルのみ残します。

## 背景
ツールチップが第一言語ラベル/他言語タブに被る・張り付くのが気になるとのフィードバックを受け、配置を再検討。位置選択の結果「多言語カードの見出し横」に決定。

## 変更内容
- 「?」ボタン＋ツールチップを `#multilingualCardBody` の「多言語機能を有効にする」見出し横へ配置（静的HTML）
- タブ帯の凡例は「第一言語」テキストラベルのみ（「?」を撤去）
- ツールチップは `position: fixed` + JS で位置計算し、カードの `overflow:hidden` にクリップされないようにした（多言語 ON/OFF どちらでも全文表示）
- スクロール/リサイズ/Esc/外側クリックで閉じる。クリック開閉・`aria-expanded`・`role="tooltip"` は維持
- 文言を配置に合わせて調整（「この枠」表現を除去）

## 検証（Playwright・実操作）
- 「?」がカード内に配置・タブ帯には不在
- 多言語 OFF（カードが低い状態）でもツールチップがビューポート内に全文表示（クリップなし）
- 多言語 ON でも同様、Esc/外側クリック/スクロールで閉じる
- ドラッグ昇格＋トースト等の既存操作は維持、コンソールエラー0件

## 対象ファイル
- `02_dashboard/src/surveyCreation-v2.js`
- `02_dashboard/service-top-style.css`
- `02_dashboard/surveyCreation.html`
- `02_dashboard/surveyCreation-v2.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)