### PR TITLE
fix(survey): 第一言語チップの余白を詰めて言語名を中央に

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -3065,14 +3065,17 @@ body.dark-mode .outline-highlight {
     box-shadow: 0 2px 5px rgba(15, 23, 42, 0.08);
 }
 /* 第一言語チップ（枠の中・グリップ無し・ドラッグ不可・透明背景）
-   min-width で枠を凡例「第一言語 ?」より広く保ち、ラベルの折り返しを防ぐ */
+   言語名を左右対称パディングで中央に見せる。凡例「第一言語」が収まる最小幅だけ確保 */
 .lang-chip--primary {
     background: transparent;
     border-color: transparent;
     box-shadow: none;
-    padding: 7px 14px;
-    min-width: 96px;
+    padding: 7px 16px;
+    min-width: 64px;
+    justify-content: center;
+    text-align: center;
 }
+.lang-chip--primary .lang-chip__name { text-align: center; }
 .lang-chip--primary:hover { background: #eef6ff; }
 /* 編集中（アクティブ）の言語を示す控えめな強調 */
 .lang-chip.active {


### PR DESCRIPTION
## 概要
「第一言語」の枠内で言語名（日本語）が右に寄って見える余白を解消し、中央に配置しました。

## 原因
「?」ヘルプを多言語カードへ移設した際、以前「第一言語 ?」を収めるために付けていた `min-width: 96px` が過大になり、短い言語名（日本語）の右側に余白が生じて中央からずれて見えていました。

## 変更内容
- `.lang-chip--primary` の `min-width` を 96px → 64px（凡例「第一言語」が収まる安全フロア）に縮小
- `justify-content: center` / `text-align: center` を付与し、言語名を枠内で中央寄せ

## 検証（Playwright 測定）
- 言語名の中心と枠の中心が一致（name_center=173 / chip_center=173）
- 枠幅 110px → 88px に縮小し右余白を解消
- 凡例「第一言語」は1行を維持し枠内に収まる（legend_right=202 < fieldset_right=218）

## 対象ファイル
- `02_dashboard/service-top-style.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)