### PR TITLE
fix(survey): 言語タブ関連のUX/a11y 3点を修正

### DIFF
--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -521,17 +521,14 @@ function makeLangChip(langCode, isPrimary, canReorder) {
   // aria-label はチップ内の全テキストを上書きするため、後から付く「未入力 N」バッジは
   // updateTranslationBadges() がこの基本ラベルに件数を連結して同期する
   const baseLabel = isPrimary ? `${langName}（第一言語）` : langName;
-  let title;
-  if (!canReorder) title = 'クリックまたはEnter/Spaceで編集対象に';
-  else if (isPrimary) title = 'クリック/Enter/Spaceで編集対象に、矢印キーで移動、Ctrl+矢印で並べ替え';
-  else title = 'クリック/Enter/Spaceで編集対象に、矢印キーで移動、Ctrl+矢印またはドラッグで並べ替え';
+  // 操作説明は per-chip の title には持たせない（矢印移動のたびに accessible description として
+  // 冗長に読み上げられるため）。操作方法は多言語カードの「?」ツールチップに集約している。
 
   const chip = el('div', {
     class: `lang-chip${isPrimary ? ' lang-chip--primary' : ''}${isActive ? ' active' : ''}`,
     'data-lang': langCode,
     role: 'button',
     tabindex: isActive ? '0' : '-1',
-    title,
     'aria-label': baseLabel,
     'data-base-label': baseLabel,
     onclick: () => activateLangTab(langCode),
@@ -1188,6 +1185,18 @@ function checkValidationForSection(idOrFn) {
   return false;
 }
 
+// 設問見出し・ナビ用の表示テキスト。第一言語が未入力なら他の入力済み言語へフォールバックする。
+// （第一言語を未翻訳の言語に入れ替えた直後、見出しが一斉にプレースホルダー化して
+//   「データが消えた」ように見える問題を防ぐ。翻訳が必要なことは未入力バッジ側で示す）
+function questionDisplayText(q) {
+  const t = (q && q.text) || {};
+  if (t[currentLangs[0]]) return t[currentLangs[0]];
+  for (const lang of currentLangs) {
+    if (t[lang]) return t[lang];
+  }
+  return '設問文を入力してください';
+}
+
 function updateOutline() {
   const outlineList = document.getElementById('outline-questions-list');
   if (!outlineList) return;
@@ -1208,7 +1217,7 @@ function updateOutline() {
   outlineList.innerHTML = '';
   cards.forEach((card, i) => {
     const q = questions.find(q => q.id === card.dataset.questionId);
-    const textStr = q.text?.[currentLangs[0]] || '設問文を入力してください';
+    const textStr = questionDisplayText(q);
     
     // Validate choice length
     let hasError = CHOICE_TYPES.has(q.type) && (!q.options || q.options.length < 2);
@@ -1426,7 +1435,7 @@ function buildQuestionCard(q, index) {
     'anim-ms': '200',
   });
 
-  const summaryText = el('p', { class: 'text-sm font-bold text-gray-800 truncate flex-1 min-w-0 px-2', 'data-question-summary-text': '' }, q.text[currentLangs[0]] || '設問文を入力してください');
+  const summaryText = el('p', { class: 'text-sm font-bold text-gray-800 truncate flex-1 min-w-0 px-2', 'data-question-summary-text': '' }, questionDisplayText(q));
 
   const actionGroup = el('div', { class: 'flex items-center gap-1 ml-auto shrink-0 opacity-0 group-hover:opacity-100 transition-opacity' });
 
@@ -1498,7 +1507,7 @@ function buildBasicSection(q, cardNode, requiredBadge) {
         q.text[lang] = e.target.value;
         if (isFirst) {
           const sum = cardNode.querySelector('[data-question-summary-text]');
-          if (sum) sum.textContent = e.target.value || '設問文を入力してください';
+          if (sum) sum.textContent = questionDisplayText(q);
           section.querySelectorAll('[data-ref-hint]').forEach(hint => {
             hint.textContent = e.target.value || '';
             hint.classList.toggle('hidden', !e.target.value);

--- a/02_dashboard/surveyCreation-v2.html
+++ b/02_dashboard/surveyCreation-v2.html
@@ -441,7 +441,7 @@
                     <div class="min-w-0">
                       <p class="font-bold text-sm text-amber-800 leading-tight flex items-center gap-1.5">多言語機能を有効にする<button id="langHelpBtn" class="lang-help" type="button" aria-expanded="false" aria-describedby="langPrimaryTip" aria-label="第一言語について">?</button></p>
                       <p class="text-xs text-amber-700/70 mt-0.5 leading-snug">複数言語でアンケートを提供します。</p>
-                      <div id="langPrimaryTip" class="lang-tip" role="tooltip" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
+                      <div id="langPrimaryTip" class="lang-tip" aria-live="polite" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
                     </div>
                     <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
                       <input type="checkbox" id="multilingualEnabledToggle" class="sr-only peer">

--- a/02_dashboard/surveyCreation.html
+++ b/02_dashboard/surveyCreation.html
@@ -529,7 +529,7 @@
                     <div class="min-w-0">
                       <p class="font-bold text-sm text-amber-800 leading-tight flex items-center gap-1.5">多言語機能を有効にする<button id="langHelpBtn" class="lang-help" type="button" aria-expanded="false" aria-describedby="langPrimaryTip" aria-label="第一言語について">?</button></p>
                       <p class="text-xs text-amber-700/70 mt-0.5 leading-snug">複数言語でアンケートを提供します。</p>
-                      <div id="langPrimaryTip" class="lang-tip" role="tooltip" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
+                      <div id="langPrimaryTip" class="lang-tip" aria-live="polite" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
                     </div>
                     <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
                       <input type="checkbox" id="multilingualEnabledToggle" class="sr-only peer">


### PR DESCRIPTION
## 概要
言語タブUIの UI/UX レビューで挙がった「実害のある3点」を修正しました。デザイン好み・トークン整理などの磨き込み項目は対象外です。

## 修正内容
### 1. 第一言語swap時に画面が「壊れて見える」問題（最重要）
第一言語を未翻訳の言語（例: English）に入れ替えると、設問見出し・設問ナビが一斉にプレースホルダー「設問文を入力してください」に変わり、「データが消えた」ように見えていた。
- `questionDisplayText(q)` ヘルパーを追加し、第一言語が未入力なら**入力済みのいずれかの言語へフォールバック表示**する（見出し／ナビ／入力欄の live 同期で共用）
- 検証: English を第一言語にしても Q1〜Q4 の見出しは日本語のまま読める（プレースホルダー化ゼロ）
- ※「翻訳が必要」を示すナビの赤ドットは正当な signal として意図的に残置（検証ロジックは非変更）

### 2. 「?」ツールチップの role 不整合（a11y）
クリック開閉の常設パネルなのに `role="tooltip"`（本来 hover/focus で自動出現する一時情報用）を付けており、SR がクリック時に読み上げない懸念があった。
- `role="tooltip"` を除去し、開いた瞬間に読み上げられるよう `aria-live="polite"` に変更

### 3. 言語チップの title 重複読み上げ（a11y）
矢印キーでチップ間を移動するたびに、長い操作説明の `title` が accessible description として冗長に読み上げられていた。
- チップの `title` を撤去（操作説明は多言語カードの「?」ツールチップに集約済み）

## 検証（Playwright・実操作、全PASS・エラー0）
- swap後の見出し・ナビともプレースホルダー化なし（フォールバック表示）
- チップに title 無し、ツールチップは role=null / aria-live=polite で開閉可

## 対象ファイル
- `02_dashboard/src/surveyCreation-v2.js`
- `02_dashboard/surveyCreation.html`
- `02_dashboard/surveyCreation-v2.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)