### PR TITLE
refactor(survey): 言語ヘルプ「?」をタブ帯右端へ＋第一言語枠を固定幅に

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -3065,13 +3065,15 @@ body.dark-mode .outline-highlight {
     box-shadow: 0 2px 5px rgba(15, 23, 42, 0.08);
 }
 /* 第一言語チップ（枠の中・グリップ無し・ドラッグ不可・透明背景）
-   言語名を左右対称パディングで中央に見せる。凡例「第一言語」が収まる最小幅だけ確保 */
+   どの言語を選んでも枠幅が変わらないよう固定幅にし、言語名を中央寄せする
+   （最長 "Tiếng Việt"=66px + 左右パディング/枠が収まる幅） */
 .lang-chip--primary {
     background: transparent;
     border-color: transparent;
     box-shadow: none;
-    padding: 7px 16px;
-    min-width: 64px;
+    box-sizing: border-box;
+    width: 106px;
+    padding: 7px 12px;
     justify-content: center;
     text-align: center;
 }
@@ -3148,6 +3150,14 @@ body.dark-mode .outline-highlight {
     padding: 3px 2px;   /* アクティブ/ドロップ受けリング(2px)がスクロールでクリップされないための余白 */
 }
 .lang-others::-webkit-scrollbar { display: none; }
+/* 「?」説明ヘルプをタブ帯の右端に固定（第一言語ボックスから離す。横スクロールしても常時見える） */
+.lang-help-slot {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    margin-left: auto;
+    padding-left: 8px;
+}
 /* レスポンシブ: 狭い幅では余白を詰めて、その他言語だけ横スクロールさせる（縦書き化を防ぐ） */
 @media (max-width: 900px) {
     .lang-tabbar__row { gap: 10px; padding: 14px; }

--- a/02_dashboard/src/surveyCreation-v2.js
+++ b/02_dashboard/src/surveyCreation-v2.js
@@ -486,6 +486,21 @@ function renderLangSelectionAndTabs() {
   }
   tabsContainer.append(divider, others);
 
+  // 説明ヘルプ「?」はタブ帯の右端（第一言語ボックスから離れた位置）に置く。
+  // sticky で帯が上部に貼り付いた状態でも見えるので発見性も確保できる。
+  const helpSlot = el('div', { class: 'lang-help-slot' });
+  const helpBtn = el('button', {
+    id: 'langHelpBtn', class: 'lang-help', type: 'button',
+    'aria-expanded': 'false', 'aria-describedby': 'langPrimaryTip', 'aria-label': '第一言語について',
+    onclick: toggleLangTip
+  }, '?');
+  const tip = el('div', {
+    id: 'langPrimaryTip', class: 'lang-tip', 'aria-live': 'polite', hidden: true
+  }, LANG_PRIMARY_TIP);
+  helpSlot.append(helpBtn, tip);
+  tabsContainer.append(helpSlot);
+  ensureLangTipDismissers();
+
   updateLangDnd();
   onLangsChanged();
 }
@@ -635,6 +650,7 @@ function updateLangDnd() {
 // ─────────────────────────────────────────
 // 第一言語の説明ツールチップ（? ボタンでクリック開閉・Esc/外側クリックで閉じる）
 // ─────────────────────────────────────────
+const LANG_PRIMARY_TIP = '『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。';
 let langTipDismissersBound = false;
 
 function closeLangTip() {
@@ -696,14 +712,6 @@ function ensureLangTipDismissers() {
     const tip = document.getElementById('langPrimaryTip');
     if (tip && !tip.hidden) closeLangTip();
   });
-}
-
-// 多言語カード見出しの「?」（静的HTML）にツールチップ開閉を配線する
-function initLangHelpTip() {
-  const btn = document.getElementById('langHelpBtn');
-  if (!btn) return;
-  btn.addEventListener('click', toggleLangTip);
-  ensureLangTipDismissers();
 }
 
 function initMultilingualToggle() {
@@ -3315,7 +3323,6 @@ async function init() {
 
   initMultilingualToggle();
   initLangTabWidthTracking();
-  initLangHelpTip();
   initFab();
   initInlineAddButton();
   initMobileAddButton();

--- a/02_dashboard/surveyCreation-v2.html
+++ b/02_dashboard/surveyCreation-v2.html
@@ -439,9 +439,8 @@
                   <!-- トグル -->
                   <div class="flex items-center justify-between gap-3">
                     <div class="min-w-0">
-                      <p class="font-bold text-sm text-amber-800 leading-tight flex items-center gap-1.5">多言語機能を有効にする<button id="langHelpBtn" class="lang-help" type="button" aria-expanded="false" aria-describedby="langPrimaryTip" aria-label="第一言語について">?</button></p>
+                      <p class="font-bold text-sm text-amber-800 leading-tight">多言語機能を有効にする</p>
                       <p class="text-xs text-amber-700/70 mt-0.5 leading-snug">複数言語でアンケートを提供します。</p>
-                      <div id="langPrimaryTip" class="lang-tip" aria-live="polite" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
                     </div>
                     <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
                       <input type="checkbox" id="multilingualEnabledToggle" class="sr-only peer">

--- a/02_dashboard/surveyCreation.html
+++ b/02_dashboard/surveyCreation.html
@@ -527,9 +527,8 @@
                   <!-- トグル -->
                   <div class="flex items-center justify-between gap-3">
                     <div class="min-w-0">
-                      <p class="font-bold text-sm text-amber-800 leading-tight flex items-center gap-1.5">多言語機能を有効にする<button id="langHelpBtn" class="lang-help" type="button" aria-expanded="false" aria-describedby="langPrimaryTip" aria-label="第一言語について">?</button></p>
+                      <p class="font-bold text-sm text-amber-800 leading-tight">多言語機能を有効にする</p>
                       <p class="text-xs text-amber-700/70 mt-0.5 leading-snug">複数言語でアンケートを提供します。</p>
-                      <div id="langPrimaryTip" class="lang-tip" aria-live="polite" hidden>『第一言語』は回答画面で最初に表示される言語です。言語タブで、他の言語を第一言語の枠へドラッグするか、Ctrl+左右キーで入れ替えられます。</div>
                     </div>
                     <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
                       <input type="checkbox" id="multilingualEnabledToggle" class="sr-only peer">


### PR DESCRIPTION
## 概要
1. 「?」説明ヘルプの位置をタブ帯の右端へ移動（第一言語ラベルの隣を避けたいというフィードバック対応）
2. 第一言語の枠が言語によって幅が変わる問題を、固定幅で解消

## 変更内容
### 「?」ヘルプをタブ帯の右端へ
- 多言語カード見出しにあった「?」を、言語タブ帯の右端（その他言語タブの後ろ・第一言語ボックスの反対側）へ移動
- sticky で帯が上部に貼り付いた状態でも「?」が見えるため、操作中のヘルプ到達性も向上
- コンテナは `role="group"`（PR #336 で対応済み）のため「?」ボタンの同居はセマンティクス上も問題なし
- ツールチップは `position: fixed` + JS でビューポート内にクランプ（右端でも見切れない）

### 第一言語の枠を固定幅に
- `.lang-chip--primary` を `box-sizing: border-box; width: 106px` の固定幅にし、言語名を中央寄せ
- 日本語(41px)/English(49px)/中文(65px)/Tiếng Việt(66px) いずれでも枠幅は一定（fieldset 120px）、最長でも切れない

## 検証（Playwright 測定）
- 「?」がタブ帯内・右端に配置、ツールチップは開閉/クランプ/Esc/外側クリック/スクロールで閉じる
- 第一言語を 日本語→English→Tiếng Việt と替えても fieldset 幅=120px / chip 幅=106px で一定、名前の切れなし
- コンソールエラー0件

## 対象ファイル
- `02_dashboard/src/surveyCreation-v2.js`
- `02_dashboard/service-top-style.css`
- `02_dashboard/surveyCreation.html`
- `02_dashboard/surveyCreation-v2.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)