### PR TITLE
fix(survey): 第一言語ラベルを枠上辺の中央に配置

### DIFF
--- a/02_dashboard/service-top-style.css
+++ b/02_dashboard/service-top-style.css
@@ -2927,11 +2927,12 @@ body.dark-mode .outline-highlight {
     border-radius: 11px;
     background: #f7faff;
 }
-/* 枠の上辺左に乗る凡例（ラベル＋?）。折り返させない */
+/* 枠の上辺中央に乗る凡例。折り返させない */
 .lang-legend {
     position: absolute;
     top: -9px;
-    left: 13px;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 6;
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## 概要
第一言語の枠上にある「第一言語」ラベルが左に寄って見える問題を、中央配置で解消しました。

## 原因
枠を固定幅(120px)にしたことで枠が広がった一方、凡例は `left: 13px` で左端固定のままだったため、相対的に左寄りに見えていた。

## 変更内容
- `.lang-legend` を `left: 50%` + `transform: translateX(-50%)` にして枠上辺の中央に配置
- 枠のサイズ・「日本語」等の言語名の中央寄せは変更なし

## 検証（Playwright 測定）
- 凡例の中心と枠の中心が一致（ともに 189px）、凡例は枠内に収まり1行表示
- コンソールエラー0件

## 対象ファイル
- `02_dashboard/service-top-style.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)