### PR TITLE
feat(login-front): 新規アカウント作成に仮登録→本登録フローを追加

### DIFF
--- a/99_backend-docs/08_e2e-testing/scenario-data.js
+++ b/99_backend-docs/08_e2e-testing/scenario-data.js
@@ -538,7 +538,7 @@
       stg_observation_status: 'stg実走済(2026-06-05)/5アカウント作成＝全件成功、作成した5アカウントとも手動ログインで/dashboard到達成功。作成直後は自動ログインせず alert「アカウントが作成されました！ログインしてください。」表示→要ログイン。メール認証なし・任意の未登録メールで作成可。',
       expected_outcome: '新規アカウントが作成でき（メール認証なし）、作成したメール/パスワードでログインしてダッシュボードに到達できる。',
       evidence_policy: 'サインアップフォーム、作成完了表示、ログイン後ダッシュボードを記録する。メール・実値はマスクする。',
-      notes: '現段階ではメール認証なし・任意の未登録メールアドレスで作成可（実走でアカウント作成まで行う場合はstgデータ追加＝要許可）。サインアップは/loginの「新規アカウント作成」モーダル（フィールド: #signup-name 任意 / #signup-email / #signup-password / #signup-password-confirm / #terms-agree 同意）。Googleサインアップ(OAuth)は別分岐。作成直後に自動ログインされるか(ログアウト要否)は実走で確認する。テスト用メールは使い捨て可。'
+      notes: '【2026-07-06フロント実装更新・要再実走】/loginの「新規アカウント作成」モーダルが仮登録→確認メールリンク（モックのデモ操作）→本登録の2段階フローに変更された。Step1(モーダル内 #signup-form): #signup-name 任意 / #signup-email / #terms-agree / #privacy-handling-agree に同意して送信すると、モーダル内でStep2（確認メール送信文言＋デモ用ボタン #signup-open-verify）に切り替わる。#signup-password / #signup-password-confirm はモーダルから撤去済み。デモボタン押下で signup-verify.html?email=... に遷移し、そこで #verify-password / #verify-password-confirm を入力・送信すると完了表示になり、#verify-go-to-login で index.html?login_email=... に戻りログイン欄がメールプリフィル済みになる。上記stg_observation_status/expected_outcomeは旧UI（単一モーダル＋password欄・alert完了）での実走記録のため、新フロー導入後にstgで再実走して整合を確認する必要がある。Googleサインアップ(OAuth)は別分岐。テスト用メールは使い捨て可。'
     },
     {
       scenario_id: 'STG-SCN-037',

--- a/css/login-front.css
+++ b/css/login-front.css
@@ -1205,6 +1205,17 @@ body.is-hero-font-dragging * {
   text-underline-offset: 3px;
 }
 
+.sub-links button.sub-links__item {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
 .form-options__checkbox-input {
   flex: 0 0 auto;
   margin-top: 4px;
@@ -2572,6 +2583,94 @@ body.is-hero-font-dragging * {
   margin: 20px 0 0;
   text-align: center;
   font-size: 0.9rem;
+}
+
+/* ==== 仮登録→本登録フロー（signup step / verify page）==== */
+.signup-step[hidden] {
+  display: none;
+}
+
+.signup-sent {
+  padding-top: 8px;
+}
+
+.signup-sent__lead {
+  margin: 0 0 16px;
+  color: var(--ink);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.signup-sent__email {
+  margin: 0 0 20px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  color: var(--ink);
+  font-weight: 700;
+  word-break: break-all;
+  background: var(--paper-muted);
+}
+
+.signup-sent__note {
+  margin: 0 0 24px;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.6;
+}
+
+.verify-page {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--paper);
+}
+
+.verify-card {
+  width: min(480px, 100%);
+  padding: 34px;
+  border-radius: 0.875rem;
+  background: var(--white);
+  box-shadow: var(--shadow);
+}
+
+.verify-card__title {
+  margin: 0 0 12px;
+  font-family: var(--sans);
+  font-size: 1.5rem;
+  color: var(--ink);
+  text-wrap: balance; /* 主要ブラウザ最新版対応・非対応環境は通常の折返しにフォールバック */
+}
+
+.verify-card__lead {
+  margin: 0 0 24px;
+  color: var(--ink-soft);
+  font-size: 0.92rem;
+  line-height: 1.7;
+}
+
+.verify-card__email {
+  margin: 0 0 24px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  color: var(--ink);
+  font-weight: 700;
+  word-break: break-all;
+  background: var(--paper-muted);
+}
+
+.verify-card__note {
+  margin: 20px 0 0;
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.verify-step[hidden] {
+  display: none;
 }
 
 @keyframes spin {

--- a/index.html
+++ b/index.html
@@ -588,56 +588,54 @@
     <div class="modal__content">
       <button class="modal__close-button" aria-label="モーダルを閉じる" type="button">×</button>
       <h2 id="signup-modal-title" class="modal__title">新規アカウント作成</h2>
-      <form id="signup-form" novalidate>
-        <div class="form-group">
-          <label for="signup-name" class="form-group__label">お名前（任意）</label>
-          <input type="text" id="signup-name" name="signup-name" class="form-group__input" autocomplete="name" placeholder="例）山田 太郎">
-          <div id="signup-name-error" class="form-group__error-message" role="alert"></div>
+      <div class="signup-step" data-signup-step="form">
+        <form id="signup-form" novalidate>
+          <div class="form-group">
+            <label for="signup-name" class="form-group__label">お名前（任意）</label>
+            <input type="text" id="signup-name" name="signup-name" class="form-group__input" autocomplete="name" placeholder="例）山田 太郎">
+            <div id="signup-name-error" class="form-group__error-message" role="alert"></div>
+          </div>
+          <div class="form-group">
+            <label for="signup-email" class="form-group__label">メールアドレス</label>
+            <input type="email" id="signup-email" name="signup-email" class="form-group__input" required aria-required="true" autocomplete="email">
+            <div id="signup-email-error" class="form-group__error-message" role="alert"></div>
+          </div>
+          <div class="form-check">
+            <label class="form-check__label">
+              <input type="checkbox" id="terms-agree" name="terms-agree" class="form-options__checkbox-input" required aria-required="true">
+              <span><a href="https://support.speed-ad.com/terms/" target="_blank" rel="noopener noreferrer">利用規約</a>と<a href="https://support.speed-ad.com/privacy/" target="_blank" rel="noopener noreferrer">プライバシーポリシー <span aria-hidden="true">↗</span></a>に同意する</span>
+            </label>
+            <div id="terms-agree-error" class="form-group__error-message" role="alert"></div>
+          </div>
+          <div class="form-check">
+            <label class="form-check__label">
+              <input type="checkbox" id="privacy-handling-agree" name="privacy-handling-agree" class="form-options__checkbox-input" required aria-required="true">
+              <span>「<a href="https://support.speed-ad.com/privacy/member-registration/" target="_blank" rel="noopener noreferrer">会員登録における個人情報の取扱いについて</a>」を確認し、同意する</span>
+            </label>
+            <div id="privacy-handling-agree-error" class="form-group__error-message" role="alert"></div>
+          </div>
+          <button class="button button--filled" type="submit"><span class="button__spinner" aria-hidden="true"></span>仮登録する</button>
+        </form>
+        <div class="divider" role="separator" aria-label="または">
+          <span class="divider__text">または</span>
         </div>
-        <div class="form-group">
-          <label for="signup-email" class="form-group__label">メールアドレス</label>
-          <input type="email" id="signup-email" name="signup-email" class="form-group__input" required aria-required="true" autocomplete="email">
-          <div id="signup-email-error" class="form-group__error-message" role="alert"></div>
-        </div>
-        <div class="form-group">
-          <label for="signup-password" class="form-group__label">パスワード</label>
-          <input type="password" id="signup-password" name="signup-password" class="form-group__input" required aria-required="true" autocomplete="new-password" aria-describedby="signup-password-error signup-password-hint">
-          <div id="signup-password-error" class="form-group__error-message" role="alert"></div>
-          <div id="signup-password-hint" class="form-group__password-hint">8文字以上、半角英数字（記号推奨）を組み合わせてください。</div>
-        </div>
-        <div class="form-group">
-          <label for="signup-password-confirm" class="form-group__label">パスワード確認</label>
-          <input type="password" id="signup-password-confirm" name="signup-password-confirm" class="form-group__input" required aria-required="true" autocomplete="new-password" aria-describedby="signup-password-confirm-error">
-          <div id="signup-password-confirm-error" class="form-group__error-message" role="alert"></div>
-        </div>
-        <div class="form-check">
-          <label class="form-check__label">
-            <input type="checkbox" id="terms-agree" name="terms-agree" class="form-options__checkbox-input" required aria-required="true">
-            <span><a href="https://support.speed-ad.com/terms/" target="_blank" rel="noopener noreferrer">利用規約</a>と<a href="https://support.speed-ad.com/privacy/" target="_blank" rel="noopener noreferrer">プライバシーポリシー <span aria-hidden="true">↗</span></a>に同意する</span>
-          </label>
-          <div id="terms-agree-error" class="form-group__error-message" role="alert"></div>
-        </div>
-        <div class="form-check">
-          <label class="form-check__label">
-            <input type="checkbox" id="privacy-handling-agree" name="privacy-handling-agree" class="form-options__checkbox-input" required aria-required="true">
-            <span>「<a href="https://support.speed-ad.com/privacy/member-registration/" target="_blank" rel="noopener noreferrer">会員登録における個人情報の取扱いについて</a>」を確認し、同意する</span>
-          </label>
-          <div id="privacy-handling-agree-error" class="form-group__error-message" role="alert"></div>
-        </div>
-        <button class="button button--filled" type="submit"><span class="button__spinner" aria-hidden="true"></span>アカウントを作成</button>
-      </form>
-      <div class="divider" role="separator" aria-label="または">
-        <span class="divider__text">または</span>
+        <button class="button button--google" type="button">
+          <img class="button--google__logo" src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="">
+          Googleでサインアップ
+        </button>
+        <p class="sub-links">アカウントをお持ちですか？ <a href="#" id="show-login-from-modal" class="sub-links__item">ログインはこちら</a></p>
       </div>
-      <button class="button button--google" type="button">
-        <img class="button--google__logo" src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="">
-        Googleでサインアップ
-      </button>
-      <p class="sub-links">アカウントをお持ちですか？ <a href="#" id="show-login-from-modal" class="sub-links__item">ログインはこちら</a></p>
+      <div class="signup-step signup-sent" data-signup-step="sent" hidden>
+        <p class="signup-sent__lead" role="status" aria-live="polite">ご入力のメールアドレス宛に確認メールを送信しました。メール内のURLから登録を完了してください。</p>
+        <p class="signup-sent__email" data-signup-sent-email></p>
+        <p class="signup-sent__note">※モック環境のため、実際にはメールは届きません。下のボタンで確認メールのリンクを開いた状態を再現できます。</p>
+        <button type="button" class="button button--filled" id="signup-open-verify">確認メールのリンクを開く</button>
+        <p class="sub-links"><button type="button" id="signup-back-to-form" class="sub-links__item">メールアドレスを入力し直す</button></p>
+      </div>
     </div>
   </div>
 
-  <script src="js/login-front.js?v=20260601-remove-mock-preview" defer></script>
+  <script src="js/login-front.js?v=20260706-signup-provisional" defer></script>
   <script src="js/login-front-fullpage.js?v=20260602-tail-scroll-stop" defer></script>
   <!-- emblem-tools（開発者向け・?emblemtools=1 で起動）。撤去時はこの行とhead内のcssリンクを削除 -->
   <script src="js/emblem-tools.js" defer></script>

--- a/js/login-front.js
+++ b/js/login-front.js
@@ -229,18 +229,20 @@
     const showLoginLinkFromModal = document.getElementById('show-login-from-modal');
     const signupNameInput = document.getElementById('signup-name');
     const signupEmailInput = document.getElementById('signup-email');
-    const signupPasswordInput = document.getElementById('signup-password');
-    const signupPasswordConfirmInput = document.getElementById('signup-password-confirm');
     const termsAgreeCheckbox = document.getElementById('terms-agree');
     const privacyHandlingAgreeCheckbox = document.getElementById('privacy-handling-agree');
     const signupNameError = document.getElementById('signup-name-error');
     const signupEmailError = document.getElementById('signup-email-error');
-    const signupPasswordError = document.getElementById('signup-password-error');
-    const signupPasswordConfirmError = document.getElementById('signup-password-confirm-error');
     const termsAgreeError = document.getElementById('terms-agree-error');
     const privacyHandlingAgreeError = document.getElementById('privacy-handling-agree-error');
     const signupAccountButton = signupForm?.querySelector('.button--filled');
     const googleButtonModal = modalContent?.querySelector('.button--google');
+    const signupModalTitle = document.getElementById('signup-modal-title');
+    const signupStepFormEl = modalContent?.querySelector('[data-signup-step="form"]');
+    const signupStepSentEl = modalContent?.querySelector('[data-signup-step="sent"]');
+    const signupSentEmailEl = modalContent?.querySelector('[data-signup-sent-email]');
+    const signupOpenVerifyButton = document.getElementById('signup-open-verify');
+    const signupBackToFormButton = document.getElementById('signup-back-to-form');
     const customerVoiceTeaserGrid = document.getElementById('customer-voice-teaser-grid');
     const customerVoiceTeaserStatus = document.getElementById('customer-voice-teaser-status');
     const publicNewsSection = document.getElementById('public-news-section');
@@ -249,6 +251,7 @@
 
     let modalReturnFocusElement = null;
     let modalFocusTimeoutId = null;
+    let pendingSignupEmail = '';
     const rememberedAccountStorageKey = 'speedad-remembered-login-id';
 
     function getModalFocusableElements() {
@@ -405,10 +408,29 @@
     function clearSignupFormErrors() {
       clearError(signupNameInput, signupNameError);
       clearError(signupEmailInput, signupEmailError);
-      clearError(signupPasswordInput, signupPasswordError);
-      clearError(signupPasswordConfirmInput, signupPasswordConfirmError);
       clearError(termsAgreeCheckbox, termsAgreeError);
       clearError(privacyHandlingAgreeCheckbox, privacyHandlingAgreeError);
+    }
+
+    function setSignupStepVisibility(step) {
+      if (!signupStepFormEl || !signupStepSentEl) {
+        return;
+      }
+      const isSentStep = step === 'sent';
+      signupStepFormEl.hidden = isSentStep;
+      signupStepSentEl.hidden = !isSentStep;
+      if (signupModalTitle) {
+        signupModalTitle.textContent = isSentStep ? '仮登録完了' : '新規アカウント作成';
+      }
+    }
+
+    function showSignupStep(step) {
+      setSignupStepVisibility(step);
+      if (step === 'sent') {
+        signupOpenVerifyButton?.focus();
+      } else {
+        signupNameInput?.focus();
+      }
     }
 
     function hideModal() {
@@ -430,6 +452,7 @@
       modalReturnFocusElement = null;
       clearSignupFormErrors();
       signupForm?.reset();
+      setSignupStepVisibility('form');
     }
 
     function displayError(inputElement, errorElement, message) {
@@ -536,6 +559,25 @@
       window.history.replaceState({}, document.title, nextUrl);
     }
 
+    function maybeApplyLoginEmailFromQuery() {
+      const searchParams = new URLSearchParams(window.location.search);
+      const loginEmail = searchParams.get('login_email');
+      if (!loginEmail) {
+        return;
+      }
+      if (emailInput) {
+        emailInput.value = loginEmail;
+      }
+      searchParams.delete('login_email');
+      const queryString = searchParams.toString();
+      // 注意: ここで hash を '#top' にフォールバックすると、直後の passwordInput.focus() が
+      // ブラウザの「フラグメントへスクロール」処理に上書きされてしまう（#top は <main> でフォーカス不可のため
+      // フォーカスが document.body に戻る）。既存の hash がある場合のみ引き継ぎ、無ければ付与しない。
+      const nextUrl = `${window.location.pathname}${queryString ? `?${queryString}` : ''}${window.location.hash || ''}`;
+      window.history.replaceState({}, document.title, nextUrl);
+      passwordInput?.focus();
+    }
+
     function validateLoginForm() {
       let isValid = true;
       clearLoginFormErrors();
@@ -568,26 +610,6 @@
         isValid = false;
       } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(signupEmailInput.value)) {
         displayError(signupEmailInput, signupEmailError, '有効なメールアドレスを入力してください。');
-        isValid = false;
-      }
-      if (!signupPasswordInput?.value) {
-        displayError(signupPasswordInput, signupPasswordError, 'パスワードを入力してください。');
-        isValid = false;
-      } else if (signupPasswordInput.value.length < 8) {
-        displayError(signupPasswordInput, signupPasswordError, 'パスワードは8文字以上である必要があります。');
-        isValid = false;
-      } else if (!/[A-Za-z]/.test(signupPasswordInput.value) || !/[0-9]/.test(signupPasswordInput.value)) {
-        displayError(signupPasswordInput, signupPasswordError, 'パスワードは半角英数字を組み合わせてください。');
-        isValid = false;
-      }
-      if (!signupPasswordConfirmInput?.value) {
-        displayError(signupPasswordConfirmInput, signupPasswordConfirmError, '確認用パスワードを入力してください。');
-        isValid = false;
-      } else if (signupPasswordConfirmInput.value !== signupPasswordInput.value) {
-        displayError(signupPasswordConfirmInput, signupPasswordConfirmError, 'パスワードが一致しません。');
-        if (signupPasswordInput.value && signupPasswordInput.getAttribute('aria-invalid') === 'false') {
-          displayError(signupPasswordInput, signupPasswordError, 'パスワードが一致しません。');
-        }
         isValid = false;
       }
       if (termsAgreeCheckbox && !termsAgreeCheckbox.checked) {
@@ -753,15 +775,14 @@
         if (!signupAccountButton) {
           return;
         }
-        showLoading(signupAccountButton, '作成中...');
+        showLoading(signupAccountButton, '送信中...');
         try {
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          alert('アカウントが作成されました！ログインしてください。');
-          hideModal();
-          if (emailInput && signupEmailInput) {
-            emailInput.value = signupEmailInput.value;
+          await new Promise((resolve) => setTimeout(resolve, 1800));
+          pendingSignupEmail = signupEmailInput?.value.trim() || '';
+          if (signupSentEmailEl) {
+            signupSentEmailEl.textContent = pendingSignupEmail;
           }
-          passwordInput?.focus();
+          showSignupStep('sent');
         } catch (error) {
           console.error('サインアップエラー:', error);
           displayError(signupEmailInput, signupEmailError, 'このメールアドレスは既に使用されています。');
@@ -771,13 +792,24 @@
       });
     }
 
+    if (signupOpenVerifyButton) {
+      signupOpenVerifyButton.addEventListener('click', () => {
+        const verifyUrl = `${resolveAppPath('signup-verify.html')}?email=${encodeURIComponent(pendingSignupEmail)}`;
+        window.location.href = verifyUrl;
+      });
+    }
+
+    if (signupBackToFormButton) {
+      signupBackToFormButton.addEventListener('click', () => {
+        showSignupStep('form');
+      });
+    }
+
     const inputsToClear = [
       emailInput,
       passwordInput,
       signupNameInput,
       signupEmailInput,
-      signupPasswordInput,
-      signupPasswordConfirmInput,
       termsAgreeCheckbox,
       privacyHandlingAgreeCheckbox
     ];
@@ -796,10 +828,6 @@
           errorElement = signupNameError;
         } else if (input === signupEmailInput) {
           errorElement = signupEmailError;
-        } else if (input === signupPasswordInput) {
-          errorElement = signupPasswordError;
-        } else if (input === signupPasswordConfirmInput) {
-          errorElement = signupPasswordConfirmError;
         } else if (input === termsAgreeCheckbox) {
           errorElement = termsAgreeError;
         } else if (input === privacyHandlingAgreeCheckbox) {
@@ -807,16 +835,6 @@
         }
         if (errorElement && input.getAttribute('aria-invalid') === 'true') {
           clearError(input, errorElement);
-        }
-        if (input.id === 'signup-password-confirm' && signupPasswordInput?.value === signupPasswordConfirmInput?.value) {
-          if (signupPasswordInput?.getAttribute('aria-invalid') === 'true' && signupPasswordError.textContent === 'パスワードが一致しません。') {
-            clearError(signupPasswordInput, signupPasswordError);
-          }
-        }
-        if (input.id === 'signup-password' && signupPasswordInput?.value === signupPasswordConfirmInput?.value) {
-          if (signupPasswordConfirmInput?.getAttribute('aria-invalid') === 'true' && signupPasswordConfirmError.textContent === 'パスワードが一致しません。') {
-            clearError(signupPasswordConfirmInput, signupPasswordConfirmError);
-          }
         }
       });
       if (input.type === 'checkbox') {
@@ -843,6 +861,7 @@
     loadPublicNews();
     loadCustomerVoiceTeasers();
     maybeOpenSignupFromIntent();
+    maybeApplyLoginEmailFromQuery();
   }
 
   const HERO_COPY_GROUPS = [

--- a/js/signup-verify.js
+++ b/js/signup-verify.js
@@ -1,0 +1,172 @@
+// モックのため実トークン検証は行わない。URLの ?email= をそのまま確認済みメールとして扱う。
+(function () {
+  'use strict';
+
+  function getButtonTextNode(buttonElement) {
+    return Array.from(buttonElement.childNodes)
+      .find((node) => node.nodeType === Node.TEXT_NODE && node.nodeValue.trim() !== '');
+  }
+
+  function showLoading(buttonElement, loadingText = '処理中...') {
+    if (!buttonElement) {
+      return;
+    }
+    buttonElement.classList.add('is-loading');
+    buttonElement.setAttribute('disabled', 'true');
+    const spinner = buttonElement.querySelector('.button__spinner');
+    if (spinner) {
+      spinner.style.display = 'inline-block';
+    }
+    const textNode = getButtonTextNode(buttonElement);
+    buttonElement.dataset.originalText = textNode ? textNode.nodeValue : buttonElement.textContent;
+    if (textNode) {
+      textNode.nodeValue = loadingText;
+    } else {
+      buttonElement.textContent = loadingText;
+    }
+  }
+
+  function hideLoading(buttonElement) {
+    if (!buttonElement) {
+      return;
+    }
+    buttonElement.classList.remove('is-loading');
+    buttonElement.removeAttribute('disabled');
+    const spinner = buttonElement.querySelector('.button__spinner');
+    if (spinner) {
+      spinner.style.display = 'none';
+    }
+    if (buttonElement.dataset.originalText) {
+      const textNode = getButtonTextNode(buttonElement);
+      if (textNode) {
+        textNode.nodeValue = buttonElement.dataset.originalText;
+      } else {
+        buttonElement.textContent = buttonElement.dataset.originalText;
+      }
+      delete buttonElement.dataset.originalText;
+    }
+  }
+
+  function displayError(inputElement, errorElement, message) {
+    if (!inputElement || !errorElement) {
+      return;
+    }
+    errorElement.textContent = message;
+    inputElement.setAttribute('aria-invalid', message !== '');
+  }
+
+  function clearError(inputElement, errorElement) {
+    if (!inputElement || !errorElement) {
+      return;
+    }
+    errorElement.textContent = '';
+    inputElement.setAttribute('aria-invalid', 'false');
+  }
+
+  function bootstrapSignupVerify() {
+    const verifyForm = document.getElementById('verify-form');
+    const passwordInput = document.getElementById('verify-password');
+    const passwordConfirmInput = document.getElementById('verify-password-confirm');
+    const passwordError = document.getElementById('verify-password-error');
+    const passwordConfirmError = document.getElementById('verify-password-confirm-error');
+    const submitButton = verifyForm?.querySelector('.button--filled');
+    const emailDisplayEl = document.querySelector('[data-verify-email]');
+    const stepPasswordEl = document.querySelector('[data-verify-step="password"]');
+    const stepDoneEl = document.querySelector('[data-verify-step="done"]');
+    const goToLoginButton = document.getElementById('verify-go-to-login');
+    const verifyCardEl = document.querySelector('.verify-card');
+
+    const searchParams = new URLSearchParams(window.location.search);
+    const email = searchParams.get('email') || '';
+
+    if (emailDisplayEl) {
+      emailDisplayEl.textContent = email ? `確認済みメールアドレス: ${email}` : '確認済みメールアドレス: 不明';
+    }
+
+    function clearFormErrors() {
+      clearError(passwordInput, passwordError);
+      clearError(passwordConfirmInput, passwordConfirmError);
+    }
+
+    function validateForm() {
+      let isValid = true;
+      clearFormErrors();
+      if (!passwordInput?.value) {
+        displayError(passwordInput, passwordError, 'パスワードを入力してください。');
+        isValid = false;
+      } else if (passwordInput.value.length < 8) {
+        displayError(passwordInput, passwordError, 'パスワードは8文字以上である必要があります。');
+        isValid = false;
+      } else if (!/[A-Za-z]/.test(passwordInput.value) || !/[0-9]/.test(passwordInput.value)) {
+        displayError(passwordInput, passwordError, 'パスワードは半角英数字を組み合わせてください。');
+        isValid = false;
+      }
+      if (!passwordConfirmInput?.value) {
+        displayError(passwordConfirmInput, passwordConfirmError, '確認用パスワードを入力してください。');
+        isValid = false;
+      } else if (passwordConfirmInput.value !== passwordInput.value) {
+        displayError(passwordConfirmInput, passwordConfirmError, 'パスワードが一致しません。');
+        isValid = false;
+      }
+      return isValid;
+    }
+
+    function showDoneStep() {
+      if (!stepPasswordEl || !stepDoneEl) {
+        return;
+      }
+      stepPasswordEl.hidden = true;
+      stepDoneEl.hidden = false;
+      // リージョン名(aria-labelledby)を完了ステップの見出しに付け替える。
+      // 差し替えないと完了後も「パスワードの設定」のままとリージョン名が読まれてしまう。
+      verifyCardEl?.setAttribute('aria-labelledby', 'verify-title-done');
+      goToLoginButton?.focus();
+    }
+
+    [passwordInput, passwordConfirmInput].forEach((input) => {
+      if (!input) {
+        return;
+      }
+      input.addEventListener('input', () => {
+        const errorElement = input === passwordInput ? passwordError : passwordConfirmError;
+        if (input.getAttribute('aria-invalid') === 'true') {
+          clearError(input, errorElement);
+        }
+      });
+    });
+
+    if (verifyForm) {
+      verifyForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!validateForm()) {
+          return;
+        }
+        if (!submitButton) {
+          return;
+        }
+        showLoading(submitButton, '登録中...');
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 1500));
+          showDoneStep();
+        } finally {
+          hideLoading(submitButton);
+        }
+      });
+    }
+
+    if (goToLoginButton) {
+      goToLoginButton.addEventListener('click', () => {
+        // index.html と signup-verify.html は同一ディレクトリ配置前提の相対パス。
+        window.location.href = `index.html?login_email=${encodeURIComponent(email)}`;
+      });
+    }
+
+    passwordInput?.focus();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootstrapSignupVerify);
+  } else {
+    bootstrapSignupVerify();
+  }
+})();

--- a/signup-verify.html
+++ b/signup-verify.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>本登録 - SPEED AD</title>
+  <link rel="icon" href="img/logo2.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/login-front.css?v=20260706-signup-provisional">
+</head>
+<body>
+  <main class="verify-page">
+    <div class="verify-card" role="region" aria-labelledby="verify-title">
+      <div class="verify-step" data-verify-step="password">
+        <h1 id="verify-title" class="verify-card__title">パスワードの設定</h1>
+        <p class="verify-card__lead">メールアドレスの確認が完了しました。パスワードを設定して登録を完了してください。</p>
+        <p class="verify-card__email" data-verify-email></p>
+        <form id="verify-form" novalidate>
+          <div class="form-group">
+            <label for="verify-password" class="form-group__label">パスワード</label>
+            <input type="password" id="verify-password" name="verify-password" class="form-group__input" required aria-required="true" autocomplete="new-password" aria-describedby="verify-password-error verify-password-hint">
+            <div id="verify-password-error" class="form-group__error-message" role="alert"></div>
+            <div id="verify-password-hint" class="form-group__password-hint">8文字以上、半角英数字（記号推奨）を組み合わせてください。</div>
+          </div>
+          <div class="form-group">
+            <label for="verify-password-confirm" class="form-group__label">パスワード確認</label>
+            <input type="password" id="verify-password-confirm" name="verify-password-confirm" class="form-group__input" required aria-required="true" autocomplete="new-password" aria-describedby="verify-password-confirm-error">
+            <div id="verify-password-confirm-error" class="form-group__error-message" role="alert"></div>
+          </div>
+          <button class="button button--filled" type="submit"><span class="button__spinner" aria-hidden="true"></span>登録を完了する</button>
+        </form>
+      </div>
+      <div class="verify-step" data-verify-step="done" hidden>
+        <h1 id="verify-title-done" class="verify-card__title">登録が完了しました</h1>
+        <p class="verify-card__lead" role="status" aria-live="polite">アカウントの本登録が完了しました。ログインしてサービスをご利用ください。</p>
+        <button type="button" class="button button--filled" id="verify-go-to-login">ログインへ</button>
+      </div>
+      <p class="verify-card__note">※本画面はモックです。実際のメール認証・トークン検証は行いません。</p>
+    </div>
+  </main>
+
+  <script src="js/signup-verify.js?v=20260706-signup-provisional" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## 概要

ログイン前トップ（`index.html`）の新規アカウント作成を、送信即完了のブラウザ `alert` から、実サービス想定の「**仮登録 → 確認メールのURL → 本登録**」フローに沿ったモックへ変更する。

対象はモックアップ画面。実メール送信・実トークン検証・DB処理は行わない。

## 変更内容

- **仮登録モーダルをステップ化**（`index.html` / `js/login-front.js`）
  - Step1: メールアドレス＋利用規約・個人情報取扱い同意（パスワード欄は撤去）
  - Step2: 確認メール送信の案内＋メールリンクを再現するデモ用ボタン
  - 送信時の `alert('アカウントが作成されました！')` を廃止
- **本登録ページを新設**（`signup-verify.html` / `js/signup-verify.js`）
  - メールURLの遷移先でパスワードを設定 → 登録完了 → ログイン画面へ戻りメールをプリフィル
- **モック明示**: 「モック環境のため実際にはメールは届きません」を画面上に表示
- **アクセシビリティ**: ステップ切替時のフォーカス移動、`role=status` による状態通知、完了時の `aria-labelledby` 付け替え、戻り導線の button 化
- **E2Eシナリオ**（`scenario-data.js` / STG-SCN-036）: notes に新フローと「stg再実走が必要」を追記。旧UIでの実走記録・expected_outcome は保持（本番未反映のため）

## フロー

```
[トップ] 新規アカウント作成
  → [モーダル Step1] メール＋同意 → 「仮登録する」
  → [モーダル Step2] 確認メール送信の案内＋デモ用ボタン
  → [signup-verify.html] パスワード設定 → 「登録を完了する」
  → [完了] 「ログインへ」→ ログイン欄にメールをプリフィル
```

## 検証

- Playwright 実機E2E: 主要フロー＋a11y項目 15/15 パス、コンソールエラー0件
- コードレビュー: 承認（重大0件）
- a11y監査: WCAG 2.1 AA、Must指摘（完了時の name 不整合）解消済み

## スコープ外

再送・期限切れ・エラー系画面、サーバ／DB／実トークン、スマホ最適化、システムメール仕様書（配信なし）の書き換え。

🤖 Generated with [Claude Code](https://claude.com/claude-code)