### PR TITLE
fix(login-front): 本登録のバイパスを防ぎメールをURLから排除

### DIFF
--- a/js/login-front.js
+++ b/js/login-front.js
@@ -253,6 +253,8 @@
     let modalFocusTimeoutId = null;
     let pendingSignupEmail = '';
     const rememberedAccountStorageKey = 'speedad-remembered-login-id';
+    const signupPendingEmailStorageKey = 'speedad-signup-pending-email';
+    const loginPrefillEmailStorageKey = 'speedad-login-prefill-email';
 
     function getModalFocusableElements() {
       if (!modalContent) {
@@ -559,22 +561,25 @@
       window.history.replaceState({}, document.title, nextUrl);
     }
 
-    function maybeApplyLoginEmailFromQuery() {
-      const searchParams = new URLSearchParams(window.location.search);
-      const loginEmail = searchParams.get('login_email');
+    function maybeApplyLoginEmailFromStorage() {
+      let loginEmail = '';
+      try {
+        loginEmail = sessionStorage.getItem(loginPrefillEmailStorageKey) || '';
+      } catch (storageError) {
+        console.warn('ログイン用メールを読み込めませんでした:', storageError);
+        return;
+      }
       if (!loginEmail) {
         return;
       }
       if (emailInput) {
         emailInput.value = loginEmail;
       }
-      searchParams.delete('login_email');
-      const queryString = searchParams.toString();
-      // 注意: ここで hash を '#top' にフォールバックすると、直後の passwordInput.focus() が
-      // ブラウザの「フラグメントへスクロール」処理に上書きされてしまう（#top は <main> でフォーカス不可のため
-      // フォーカスが document.body に戻る）。既存の hash がある場合のみ引き継ぎ、無ければ付与しない。
-      const nextUrl = `${window.location.pathname}${queryString ? `?${queryString}` : ''}${window.location.hash || ''}`;
-      window.history.replaceState({}, document.title, nextUrl);
+      try {
+        sessionStorage.removeItem(loginPrefillEmailStorageKey);
+      } catch (storageError) {
+        console.warn('ログイン用メールを削除できませんでした:', storageError);
+      }
       passwordInput?.focus();
     }
 
@@ -782,6 +787,12 @@
           if (signupSentEmailEl) {
             signupSentEmailEl.textContent = pendingSignupEmail;
           }
+          // メールをURLに載せず、本登録ページへの受け渡しは sessionStorage 経由にする。
+          try {
+            sessionStorage.setItem(signupPendingEmailStorageKey, pendingSignupEmail);
+          } catch (storageError) {
+            console.warn('仮登録メールを保存できませんでした:', storageError);
+          }
           showSignupStep('sent');
         } catch (error) {
           console.error('サインアップエラー:', error);
@@ -794,7 +805,9 @@
 
     if (signupOpenVerifyButton) {
       signupOpenVerifyButton.addEventListener('click', () => {
-        const verifyUrl = `${resolveAppPath('signup-verify.html')}?email=${encodeURIComponent(pendingSignupEmail)}`;
+        // メールアドレスはクエリに載せない。デモボタンは「確認メール内のリンク」を
+        // 不透明トークン(token=demo)で模す。実メールは sessionStorage 側で引き継ぐ。
+        const verifyUrl = `${resolveAppPath('signup-verify.html')}?token=demo`;
         window.location.href = verifyUrl;
       });
     }
@@ -861,7 +874,7 @@
     loadPublicNews();
     loadCustomerVoiceTeasers();
     maybeOpenSignupFromIntent();
-    maybeApplyLoginEmailFromQuery();
+    maybeApplyLoginEmailFromStorage();
   }
 
   const HERO_COPY_GROUPS = [

--- a/js/signup-verify.js
+++ b/js/signup-verify.js
@@ -1,6 +1,12 @@
-// モックのため実トークン検証は行わない。URLの ?email= をそのまま確認済みメールとして扱う。
+// モックのため実トークン検証は行わない。?email= は使わず、仮登録時に sessionStorage へ
+// 置いた保留メールを読む（URLにメールアドレスを一切載せないため）。
+// 注意: このガードはあくまでモックの導線再現。本番では認可の代替にはせず、
+// メール確認・トークン検証はサーバ側の責務として別途実装すること。
 (function () {
   'use strict';
+
+  const SIGNUP_PENDING_EMAIL_KEY = 'speedad-signup-pending-email';
+  const LOGIN_PREFILL_EMAIL_KEY = 'speedad-login-prefill-email';
 
   function getButtonTextNode(buttonElement) {
     return Array.from(buttonElement.childNodes)
@@ -63,6 +69,23 @@
     inputElement.setAttribute('aria-invalid', 'false');
   }
 
+  function readPendingSignupEmail() {
+    try {
+      return sessionStorage.getItem(SIGNUP_PENDING_EMAIL_KEY) || '';
+    } catch (storageError) {
+      console.warn('仮登録メールを読み込めませんでした:', storageError);
+      return '';
+    }
+  }
+
+  function clearPendingSignupEmail() {
+    try {
+      sessionStorage.removeItem(SIGNUP_PENDING_EMAIL_KEY);
+    } catch (storageError) {
+      console.warn('仮登録メールを削除できませんでした:', storageError);
+    }
+  }
+
   function bootstrapSignupVerify() {
     const verifyForm = document.getElementById('verify-form');
     const passwordInput = document.getElementById('verify-password');
@@ -71,16 +94,56 @@
     const passwordConfirmError = document.getElementById('verify-password-confirm-error');
     const submitButton = verifyForm?.querySelector('.button--filled');
     const emailDisplayEl = document.querySelector('[data-verify-email]');
-    const stepPasswordEl = document.querySelector('[data-verify-step="password"]');
-    const stepDoneEl = document.querySelector('[data-verify-step="done"]');
     const goToLoginButton = document.getElementById('verify-go-to-login');
+    const backToTopButton = document.getElementById('verify-back-to-top');
     const verifyCardEl = document.querySelector('.verify-card');
 
-    const searchParams = new URLSearchParams(window.location.search);
-    const email = searchParams.get('email') || '';
+    const verifyStepEls = {
+      password: document.querySelector('[data-verify-step="password"]'),
+      done: document.querySelector('[data-verify-step="done"]'),
+      invalid: document.querySelector('[data-verify-step="invalid"]')
+    };
+    const verifyStepTitleIds = {
+      password: 'verify-title',
+      done: 'verify-title-done',
+      invalid: 'verify-title-invalid'
+    };
+
+    function setActiveVerifyStep(step) {
+      Object.entries(verifyStepEls).forEach(([key, el]) => {
+        if (el) {
+          el.hidden = key !== step;
+        }
+      });
+      if (verifyCardEl && verifyStepTitleIds[step]) {
+        verifyCardEl.setAttribute('aria-labelledby', verifyStepTitleIds[step]);
+      }
+    }
+
+    const pendingEmail = readPendingSignupEmail();
 
     if (emailDisplayEl) {
-      emailDisplayEl.textContent = email ? `確認済みメールアドレス: ${email}` : '確認済みメールアドレス: 不明';
+      emailDisplayEl.textContent = pendingEmail ? `確認済みメールアドレス: ${pendingEmail}` : '確認済みメールアドレス: 不明';
+    }
+
+    function showInvalidStep() {
+      // 古い保留メールが次回の仮登録に紛れ込まないよう、ガード表示のタイミングでも後始末する。
+      clearPendingSignupEmail();
+      setActiveVerifyStep('invalid');
+      backToTopButton?.focus();
+    }
+
+    if (backToTopButton) {
+      backToTopButton.addEventListener('click', () => {
+        // index.html と signup-verify.html は同一ディレクトリ配置前提の相対パス。
+        window.location.href = 'index.html';
+      });
+    }
+
+    // 仮登録(Step1)を経ずに直接アクセスされた場合は本登録フォームを出さず、ガード表示にする。
+    if (!pendingEmail) {
+      showInvalidStep();
+      return;
     }
 
     function clearFormErrors() {
@@ -112,14 +175,7 @@
     }
 
     function showDoneStep() {
-      if (!stepPasswordEl || !stepDoneEl) {
-        return;
-      }
-      stepPasswordEl.hidden = true;
-      stepDoneEl.hidden = false;
-      // リージョン名(aria-labelledby)を完了ステップの見出しに付け替える。
-      // 差し替えないと完了後も「パスワードの設定」のままとリージョン名が読まれてしまう。
-      verifyCardEl?.setAttribute('aria-labelledby', 'verify-title-done');
+      setActiveVerifyStep('done');
       goToLoginButton?.focus();
     }
 
@@ -156,8 +212,14 @@
 
     if (goToLoginButton) {
       goToLoginButton.addEventListener('click', () => {
+        try {
+          sessionStorage.setItem(LOGIN_PREFILL_EMAIL_KEY, pendingEmail);
+        } catch (storageError) {
+          console.warn('ログイン用メールを保存できませんでした:', storageError);
+        }
+        clearPendingSignupEmail();
         // index.html と signup-verify.html は同一ディレクトリ配置前提の相対パス。
-        window.location.href = `index.html?login_email=${encodeURIComponent(email)}`;
+        window.location.href = 'index.html';
       });
     }
 

--- a/signup-verify.html
+++ b/signup-verify.html
@@ -37,7 +37,12 @@
         <p class="verify-card__lead" role="status" aria-live="polite">アカウントの本登録が完了しました。ログインしてサービスをご利用ください。</p>
         <button type="button" class="button button--filled" id="verify-go-to-login">ログインへ</button>
       </div>
-      <p class="verify-card__note">※本画面はモックです。実際のメール認証・トークン検証は行いません。</p>
+      <div class="verify-step" data-verify-step="invalid" hidden>
+        <h1 id="verify-title-invalid" class="verify-card__title">リンクが無効です</h1>
+        <p class="verify-card__lead" role="status" aria-live="polite">仮登録が確認できません。お手数ですが、最初から新規アカウント作成をやり直してください。</p>
+        <button type="button" class="button button--filled" id="verify-back-to-top">トップへ戻る</button>
+      </div>
+      <p class="verify-card__note">※本画面はモックです。実際のメール認証・トークン検証は行いません。このsessionStorageによる遷移ガードはモックの導線再現であり、本番では認可の代替にしません（メール確認・トークン検証はサーバ側の責務です）。</p>
     </div>
   </main>
 


### PR DESCRIPTION
## 概要

新規登録モック（PR #342）に対する Codex ストップ時レビューの指摘2点に対応する。

1. **本登録がバイパス可能** — `signup-verify.html` をクエリだけで直接開けば、仮登録を経ずにパスワード設定〜完了まで到達できた。
2. **メールアドレスが URL に露出** — `?email=` / `?login_email=` に平文で載り、履歴・リファラ・ログに残留していた。

モックのため実トークン・サーバ検証は作らず、モックレベルで解消する。

## 変更内容

- メール受け渡しを **`sessionStorage` 経由**に変更し、URL からメールアドレスを排除
  - `?email=` / `?login_email=` を廃止。確認メールリンクの再現は不透明な `?token=demo` のみ
- **バイパスガード**: 仮登録の保留マーカー（`speedad-signup-pending-email`）が無い直接アクセス時は、本登録フォームを出さずガード画面（`data-verify-step="invalid"`）を表示
- **stale 対策**: ガード到達時・本登録完了時に保留マーカーを `removeItem`
- ガード画面も `role=status` と `aria-labelledby` 同期を維持
- 本番ではこの storage ガードを認可の代替にしない旨を注記（メール確認・トークン検証はサーバ側の責務）

## 検証

- Playwright 実機E2E: 正常フルフロー 23/23（**訪問した全URLにメールアドレスが一度も出現しないこと**を確認）、直接アクセス→ガード表示、既存回帰 15/15、コンソールエラー0件
- security（AZKi）レビュー: 方針承認。ログイン側 storage 統一・本番非代替の注記・stale クリアの3条件を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)