### PR TITLE
fix(login-front): 本登録の解錠を遷移トークンの一致に紐づける

### DIFF
--- a/js/login-front.js
+++ b/js/login-front.js
@@ -252,9 +252,22 @@
     let modalReturnFocusElement = null;
     let modalFocusTimeoutId = null;
     let pendingSignupEmail = '';
+    let pendingSignupToken = '';
     const rememberedAccountStorageKey = 'speedad-remembered-login-id';
-    const signupPendingEmailStorageKey = 'speedad-signup-pending-email';
+    const signupPendingStorageKey = 'speedad-signup-pending';
     const loginPrefillEmailStorageKey = 'speedad-login-prefill-email';
+
+    function generateSignupToken() {
+      // モックの一意値でよいため強度は不問。使える範囲で最善のAPIにフォールバックする。
+      if (window.crypto?.randomUUID) {
+        return window.crypto.randomUUID();
+      }
+      if (window.crypto?.getRandomValues) {
+        const randomBytes = window.crypto.getRandomValues(new Uint8Array(16));
+        return Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+      }
+      return `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+    }
 
     function getModalFocusableElements() {
       if (!modalContent) {
@@ -784,14 +797,20 @@
         try {
           await new Promise((resolve) => setTimeout(resolve, 1800));
           pendingSignupEmail = signupEmailInput?.value.trim() || '';
+          pendingSignupToken = generateSignupToken();
           if (signupSentEmailEl) {
             signupSentEmailEl.textContent = pendingSignupEmail;
           }
           // メールをURLに載せず、本登録ページへの受け渡しは sessionStorage 経由にする。
+          // token を紐づけておき、本登録側では「保留マーカーの存在」だけでなく
+          // URLのtokenと保存tokenの一致を解錠条件にする（古いマーカーの使い回し防止）。
           try {
-            sessionStorage.setItem(signupPendingEmailStorageKey, pendingSignupEmail);
+            sessionStorage.setItem(signupPendingStorageKey, JSON.stringify({
+              email: pendingSignupEmail,
+              token: pendingSignupToken
+            }));
           } catch (storageError) {
-            console.warn('仮登録メールを保存できませんでした:', storageError);
+            console.warn('仮登録情報を保存できませんでした:', storageError);
           }
           showSignupStep('sent');
         } catch (error) {
@@ -806,8 +825,8 @@
     if (signupOpenVerifyButton) {
       signupOpenVerifyButton.addEventListener('click', () => {
         // メールアドレスはクエリに載せない。デモボタンは「確認メール内のリンク」を
-        // 不透明トークン(token=demo)で模す。実メールは sessionStorage 側で引き継ぐ。
-        const verifyUrl = `${resolveAppPath('signup-verify.html')}?token=demo`;
+        // 今回発行したトークンで模す。本登録側はこのtokenと保存tokenの一致を見て解錠する。
+        const verifyUrl = `${resolveAppPath('signup-verify.html')}?token=${encodeURIComponent(pendingSignupToken)}`;
         window.location.href = verifyUrl;
       });
     }

--- a/js/signup-verify.js
+++ b/js/signup-verify.js
@@ -1,11 +1,13 @@
 // モックのため実トークン検証は行わない。?email= は使わず、仮登録時に sessionStorage へ
-// 置いた保留メールを読む（URLにメールアドレスを一切載せないため）。
+// 置いた保留情報（email + token）を読む（URLにメールアドレスを一切載せないため）。
+// 解錠条件は「保留情報が存在し、かつURLのtokenと保存tokenが一致すること」。
+// 保留情報の"存在"だけでは解錠しない（古いマーカーが残っているだけの直リンクを弾くため）。
 // 注意: このガードはあくまでモックの導線再現。本番では認可の代替にはせず、
 // メール確認・トークン検証はサーバ側の責務として別途実装すること。
 (function () {
   'use strict';
 
-  const SIGNUP_PENDING_EMAIL_KEY = 'speedad-signup-pending-email';
+  const SIGNUP_PENDING_KEY = 'speedad-signup-pending';
   const LOGIN_PREFILL_EMAIL_KEY = 'speedad-login-prefill-email';
 
   function getButtonTextNode(buttonElement) {
@@ -69,20 +71,34 @@
     inputElement.setAttribute('aria-invalid', 'false');
   }
 
-  function readPendingSignupEmail() {
+  function readPendingSignup() {
+    let raw = null;
     try {
-      return sessionStorage.getItem(SIGNUP_PENDING_EMAIL_KEY) || '';
+      raw = sessionStorage.getItem(SIGNUP_PENDING_KEY);
     } catch (storageError) {
-      console.warn('仮登録メールを読み込めませんでした:', storageError);
-      return '';
+      console.warn('仮登録情報を読み込めませんでした:', storageError);
+      return null;
+    }
+    if (!raw) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || !parsed.email || !parsed.token) {
+        return null;
+      }
+      return { email: String(parsed.email), token: String(parsed.token) };
+    } catch (parseError) {
+      console.warn('仮登録情報の形式が不正です:', parseError);
+      return null;
     }
   }
 
-  function clearPendingSignupEmail() {
+  function clearPendingSignup() {
     try {
-      sessionStorage.removeItem(SIGNUP_PENDING_EMAIL_KEY);
+      sessionStorage.removeItem(SIGNUP_PENDING_KEY);
     } catch (storageError) {
-      console.warn('仮登録メールを削除できませんでした:', storageError);
+      console.warn('仮登録情報を削除できませんでした:', storageError);
     }
   }
 
@@ -120,15 +136,9 @@
       }
     }
 
-    const pendingEmail = readPendingSignupEmail();
-
-    if (emailDisplayEl) {
-      emailDisplayEl.textContent = pendingEmail ? `確認済みメールアドレス: ${pendingEmail}` : '確認済みメールアドレス: 不明';
-    }
-
     function showInvalidStep() {
-      // 古い保留メールが次回の仮登録に紛れ込まないよう、ガード表示のタイミングでも後始末する。
-      clearPendingSignupEmail();
+      // 古い保留情報が次回の仮登録に紛れ込まないよう、ガード表示のタイミングでも後始末する。
+      clearPendingSignup();
       setActiveVerifyStep('invalid');
       backToTopButton?.focus();
     }
@@ -140,10 +150,22 @@
       });
     }
 
-    // 仮登録(Step1)を経ずに直接アクセスされた場合は本登録フォームを出さず、ガード表示にする。
-    if (!pendingEmail) {
+    const pendingSignup = readPendingSignup();
+    const urlToken = new URLSearchParams(window.location.search).get('token') || '';
+
+    // 解錠条件: 保留情報が存在し、かつURLのtokenと保存tokenが一致すること。
+    // 「保留情報の存在」だけでは解錠しない（tokenなし／不一致は直リンク扱いでガード）。
+    const isUnlocked = Boolean(pendingSignup) && Boolean(urlToken) && urlToken === pendingSignup.token;
+
+    if (!isUnlocked) {
       showInvalidStep();
       return;
+    }
+
+    const pendingEmail = pendingSignup.email;
+
+    if (emailDisplayEl) {
+      emailDisplayEl.textContent = `確認済みメールアドレス: ${pendingEmail}`;
     }
 
     function clearFormErrors() {
@@ -217,7 +239,7 @@
         } catch (storageError) {
           console.warn('ログイン用メールを保存できませんでした:', storageError);
         }
-        clearPendingSignupEmail();
+        clearPendingSignup();
         // index.html と signup-verify.html は同一ディレクトリ配置前提の相対パス。
         window.location.href = 'index.html';
       });


### PR DESCRIPTION
## 概要

Codex ストップ時レビューの追加指摘「stale signup marker can still unlock verify form」に対応する。

これまでは本登録画面が保留マーカー（`speedad-signup-pending-email`）の**存在だけ**で解錠され、URL の `?token=demo` は照合していなかった。そのため一度でも仮登録した同一タブセッションでは、確認メールのデモリンクを踏まずに `signup-verify.html` を直接開いてもフォームが解錠されていた。

## 変更内容

- 仮登録時に per-registration の不透明トークンを発行し、`sessionStorage` に `{email, token}` として保存（キーを `speedad-signup-pending` にリネーム）
- 確認メールリンクの再現（デモボタン）は発行トークンを `?token=` に載せる（メールは引き続き URL に載せない）
- 本登録側の解錠条件を「**保留情報あり ＋ URL token あり ＋ 保存 token と一致**」に変更。token 無し／不一致はガード表示
- 古いマーカーの使い回しを防止（存在のみでは解錠しない）

トークンはモックの一意値（`crypto.randomUUID` → `getRandomValues` → 時刻+乱数のフォールバック）。実トークン検証はサーバ側の責務としてモックでは作らない。

## 検証

- Playwright 実機E2E 計22チェック全パス
  - 正常フルフロー（トークン一致で解錠→完了→プリフィル、全URLにメール非出現）
  - **stale marker 回帰**: 保留マーカーがある状態で token 無し／不一致トークンで直接アクセス → いずれもガード表示・本登録フォーム非表示
  - pending 無しの直接アクセス → ガード表示
  - a11y（`role=status`・`aria-labelledby` 同期・フォーカス）維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)