### PR TITLE
fix(login-front): 無効な本登録アクセスで有効な仮登録を消さない

### DIFF
--- a/js/signup-verify.js
+++ b/js/signup-verify.js
@@ -137,8 +137,9 @@
     }
 
     function showInvalidStep() {
-      // 古い保留情報が次回の仮登録に紛れ込まないよう、ガード表示のタイミングでも後始末する。
-      clearPendingSignup();
+      // ここで保留情報を消さないこと。無効な直リンク到達（token無し／不一致）で消すと、
+      // 正規の確認メールリンク（?token=一致）をまだ踏んでいない有効な仮登録まで
+      // 巻き添えで破棄してしまう。保留情報は次の仮登録で上書き／本登録完了時に削除される。
       setActiveVerifyStep('invalid');
       backToTopButton?.focus();
     }


### PR DESCRIPTION
## 概要

Codex ストップ時レビューの追加指摘「invalid verification attempts erase a valid pending signup」に対応する。

PR #344 でガード時に保留情報を削除する後始末を入れたが、これが過剰だった。無効な直リンク到達（`?token` 無し／不一致）でガードするたびに保留情報を消していたため、有効な仮登録がある状態で無関係な無効アクセスが起きると、その有効マーカーまで巻き添えで消え、本人が正規の確認メールリンク（`?token=一致`）を踏んでも後からガードされ、仮登録が壊れていた。

## 変更内容

- `showInvalidStep()` から `clearPendingSignup()` の呼び出しを削除
- 保留情報の後始末は「次の仮登録での上書き」と「本登録完了時の削除」で担保（完了時の `clearPendingSignup` は維持）

トークン一致による解錠ガード（#344）はクリアと独立のため、この変更後も維持される。

## 検証

- Playwright 実機E2E 計27チェック全パス
  - **核心リグレッション**: 仮登録済み（マーカー有効）状態で不一致トークンの直リンク到達 → ガード表示かつ `speedad-signup-pending` が残存 → 直後に正規トークンでアクセスすると本登録フォームが解錠（無効アクセスで有効な仮登録が壊れない）
  - 正常フルフロー（全URLにメール非出現）、pending 無し直アクセスのガード、完了時のマーカー削除、a11y 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)