### PR TITLE
fix: ログイン前ワードマークの比率を調整

### DIFF
--- a/css/login-front.css
+++ b/css/login-front.css
@@ -343,13 +343,13 @@ img {
   width: var(--speed-ad-wordmark-first-line-width, 4.275em);
   color: var(--white);
   font-family: "SPEED AD Wordmark", serif;
-  font-size: clamp(6.1rem, 10vw, 8.75rem);
+  font-size: clamp(6.1rem, 10.8vw, 8.25rem);
   font-synthesis: none;
   font-weight: 400;
   font-kerning: normal;
   font-feature-settings: "kern" 1;
   letter-spacing: normal;
-  line-height: 0.815;
+  line-height: 0.79;
   overflow-wrap: normal;
   cursor: text;
   text-rendering: geometricPrecision;
@@ -444,10 +444,10 @@ body.is-hero-font-dragging * {
 .hero__statement {
   margin: 8px 0 0;
   font-family: var(--serif);
-  font-size: 36px;
+  font-size: 32px;
   font-weight: 500;
-  letter-spacing: 0.04em;
-  line-height: 1.48;
+  letter-spacing: 0.025em;
+  line-height: 1.42;
   transform: translate(var(--hero-statement-x, 0), var(--hero-statement-y, 0));
   transform-origin: left top;
 }
@@ -770,7 +770,7 @@ body.is-hero-font-dragging * {
 
 .hero__lead {
   max-width: 520px;
-  margin: 18px 0 0;
+  margin: 16px 0 0;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: 0.02em;
@@ -2881,6 +2881,12 @@ body.is-hero-font-dragging * {
 
   .hero__brand-text {
     font-size: clamp(2.85rem, 13.65vw, 4.83rem);
+  }
+
+  .hero__statement {
+    font-size: clamp(1.35rem, 6vw, 1.5rem);
+    letter-spacing: 0.015em;
+    line-height: 1.5;
   }
 
   .hero__actions {

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="fonts/speed-ad-wordmark.css?v=20260810-optical-balance">
-  <link rel="stylesheet" href="css/login-front.css?v=20260810-optical-balance">
+  <link rel="stylesheet" href="css/login-front.css?v=20260810-smart-balance-v3">
   <!-- emblem-tools（開発者向け・?emblemtools=1 で起動）。この行＋下部の script を消せば撤去完了 -->
   <link rel="stylesheet" href="css/emblem-tools.css">
   <style>

--- a/tests/brand-assets.test.mjs
+++ b/tests/brand-assets.test.mjs
@@ -107,10 +107,12 @@ test('login hero uses the custom wordmark font as one copyable text string', asy
   assert.match(fontCss, /--speed-ad-wordmark-block-offset:\s*-0\.088em;/);
   assert.match(fontCss, /--speed-ad-wordmark-first-line-indent:\s*-0\.048em;/);
   assert.match(css, /\.hero__brand-text\s*\{[\s\S]*?font-family:\s*"SPEED AD Wordmark"[\s\S]*?user-select:\s*text;/);
-  assert.match(css, /\.hero__brand-text\s*\{[\s\S]*?font-size:\s*clamp\(6\.1rem,\s*10vw,\s*8\.75rem\);/);
+  assert.match(css, /\.hero__brand-text\s*\{[\s\S]*?font-size:\s*clamp\(6\.1rem,\s*10\.8vw,\s*8\.25rem\);/);
+  assert.match(css, /\.hero__brand-text\s*\{[\s\S]*?line-height:\s*0\.79;/);
   assert.match(css, /\.hero__brand-text\s*\{[\s\S]*?font-feature-settings:\s*"kern" 1;[\s\S]*?letter-spacing:\s*normal;/);
   assert.match(css, /\.hero__brand-text\s*\{[\s\S]*?left:\s*var\(--speed-ad-wordmark-block-offset,[\s\S]*?text-indent:\s*var\(--speed-ad-wordmark-first-line-indent,/);
-  assert.match(css, /\.hero__statement\s*\{[\s\S]*?margin:\s*8px 0 0;/);
+  assert.match(css, /\.hero__statement\s*\{[\s\S]*?margin:\s*8px 0 0;[\s\S]*?font-size:\s*32px;[\s\S]*?letter-spacing:\s*0\.025em;[\s\S]*?line-height:\s*1\.42;/);
+  assert.match(css, /@media \(max-width:\s*760px\)[\s\S]*?\.hero__statement\s*\{[\s\S]*?font-size:\s*clamp\(1\.35rem,\s*6vw,\s*1\.5rem\);/);
   assert.match(fontBuilder, /def centered_left_side_bearing\([\s\S]*?advance - ink_width[\s\S]*?\/ 2/);
   assert.match(fontBuilder, /def setup_wordmark_gpos\([\s\S]*?addOpenTypeFeaturesFromString/);
   assert.equal(font.subarray(0, 4).toString('ascii'), 'wOF2');


### PR DESCRIPTION
## 変更内容
- ログイン前ヒーローのワードマークを最大132pxへ調整
- ワードマークの行間とタグラインのサイズ・字間を引き締め
- モバイルではタグラインを1行で表示しやすいサイズへ調整
- CSSキャッシュ識別子とブランドアセットテストを更新

## 動作確認
- `node --test tests/brand-assets.test.mjs`（5件成功）
- デスクトップ幅でワードマーク約128px、横スクロールなし
- モバイル幅390pxで横スクロールなし
- ブラウザコンソールのエラー・警告なし

## 影響範囲
- ログイン前ページのヒーロー表示のみ
- 公式ワードマークの字形、Webフォント、文字選択・コピー挙動は変更なし
- ログイン処理、画面遷移、ログイン後画面への影響なし