### PR TITLE
fix: 導入事例の遷移をモック内に統一

### DIFF
--- a/05_support/customer-voices/company-monitor/index.html
+++ b/05_support/customer-voices/company-monitor/index.html
@@ -34,7 +34,7 @@
       </a>
       <nav class="voice-nav" aria-label="導入事例ページのナビゲーション">
         <a class="voice-nav__link" href="../">一覧へ戻る</a>
-        <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+        <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
       </nav>
     </div>
   </header>
@@ -50,8 +50,8 @@
             <p class="company-story-hero__summary" id="voice-hero-summary">表示内容を準備しています。</p>
             <div class="company-story-hero__meta" id="voice-hero-meta"></div>
             <div class="voice-hero__actions">
-              <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
-              <a class="voice-button voice-button--secondary" href="https://speed-ad.com/#top">ログインはこちら</a>
+              <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
+              <a class="voice-button voice-button--secondary" href="../../../index.html#top">ログインはこちら</a>
             </div>
           </div>
 
@@ -122,13 +122,13 @@
         </p>
         <div class="voice-cta__actions">
           <a class="voice-button voice-button--secondary" href="../">他の事例を見る</a>
-          <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+          <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
         </div>
       </section>
 
       <footer class="voice-footer">
         <p>公開可能な範囲で内容を要約し、企業名・担当者名・固有情報を匿名化した導入事例です。</p>
-        <a class="voice-nav__link" href="https://speed-ad.com/#top">ログイン前ページへ戻る</a>
+        <a class="voice-nav__link" href="../../../index.html#top">ログイン前ページへ戻る</a>
       </footer>
     </div>
   </main>

--- a/05_support/customer-voices/index.html
+++ b/05_support/customer-voices/index.html
@@ -32,8 +32,8 @@
         </span>
       </a>
       <nav class="voice-nav" aria-label="導入事例ページのナビゲーション">
-        <a class="voice-nav__link" href="https://speed-ad.com/#top">ログインはこちら</a>
-        <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+        <a class="voice-nav__link" href="../../index.html#top">ログインはこちら</a>
+        <a class="voice-button voice-button--primary" href="../../index.html?intent=signup#top">無料ではじめる</a>
       </nav>
     </div>
   </header>
@@ -50,8 +50,8 @@
               まず全体像を見てから、自社に近い運用イメージの詳細へ進めます。
             </p>
             <div class="voice-hero__actions">
-              <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
-              <a class="voice-button voice-button--secondary" href="https://speed-ad.com/#top">ログインはこちら</a>
+              <a class="voice-button voice-button--primary" href="../../index.html?intent=signup#top">無料ではじめる</a>
+              <a class="voice-button voice-button--secondary" href="../../index.html#top">ログインはこちら</a>
             </div>
           </div>
           <div class="voice-hero__art" data-reveal>
@@ -83,8 +83,8 @@
           ログイン前ページに戻れば、そのまま開始導線に接続できます。
         </p>
         <div class="voice-cta__actions">
-          <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
-          <a class="voice-button voice-button--secondary" href="https://speed-ad.com/#top">ログインはこちら</a>
+          <a class="voice-button voice-button--primary" href="../../index.html?intent=signup#top">無料ではじめる</a>
+          <a class="voice-button voice-button--secondary" href="../../index.html#top">ログインはこちら</a>
         </div>
       </section>
 

--- a/05_support/customer-voices/oriental-motor/index.html
+++ b/05_support/customer-voices/oriental-motor/index.html
@@ -35,7 +35,7 @@
       </a>
       <nav class="voice-nav" aria-label="導入事例ページのナビゲーション">
         <a class="voice-nav__link" href="../">一覧へ戻る</a>
-        <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+        <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
       </nav>
     </div>
   </header>
@@ -51,8 +51,8 @@
             <p class="company-story-hero__summary" id="voice-hero-summary">既存のSPEED AD利用ユーザーからの紹介をきっかけに利用を開始。本事例では、名刺データを翌営業日に納品し、利用中のCRMへの取り込みを翌々日に完了しました。</p>
             <div class="company-story-hero__meta" id="voice-hero-meta" aria-label="事例の特徴"></div>
             <div class="voice-hero__actions">
-              <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
-              <a class="voice-button voice-button--secondary" href="https://speed-ad.com/#top">ログインはこちら</a>
+              <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
+              <a class="voice-button voice-button--secondary" href="../../../index.html#top">ログインはこちら</a>
             </div>
           </div>
 
@@ -98,14 +98,14 @@
           <p>名刺データ化を起点に、次の業務へつなげたい方へ。SPEED ADのサービスをご案内します。</p>
         </div>
         <div class="voice-cta__actions">
-          <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+          <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
           <a class="voice-button voice-button--secondary" href="../">他の事例を見る</a>
         </div>
       </section>
 
       <footer class="voice-footer">
         <p>本事例は実名掲載許諾済みです。CRM製品名、担当者名などの固有情報は掲載していません。</p>
-        <a class="voice-nav__link" href="https://speed-ad.com/#top">ログイン前ページへ戻る</a>
+        <a class="voice-nav__link" href="../../../index.html#top">ログイン前ページへ戻る</a>
       </footer>
     </div>
   </main>

--- a/05_support/customer-voices/university-survey/index.html
+++ b/05_support/customer-voices/university-survey/index.html
@@ -34,7 +34,7 @@
       </a>
       <nav class="voice-nav" aria-label="導入事例ページのナビゲーション">
         <a class="voice-nav__link" href="../">一覧へ戻る</a>
-        <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+        <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
       </nav>
     </div>
   </header>
@@ -50,8 +50,8 @@
             <p class="company-story-hero__summary" id="voice-hero-summary">表示内容を準備しています。</p>
             <div class="company-story-hero__meta" id="voice-hero-meta"></div>
             <div class="voice-hero__actions">
-              <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
-              <a class="voice-button voice-button--secondary" href="https://speed-ad.com/#top">ログインはこちら</a>
+              <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
+              <a class="voice-button voice-button--secondary" href="../../../index.html#top">ログインはこちら</a>
             </div>
           </div>
 
@@ -131,13 +131,13 @@
         </p>
         <div class="voice-cta__actions">
           <a class="voice-button voice-button--secondary" href="../">他の事例を見る</a>
-          <a class="voice-button voice-button--primary" href="https://speed-ad.com/?intent=signup#top">無料ではじめる</a>
+          <a class="voice-button voice-button--primary" href="../../../index.html?intent=signup#top">無料ではじめる</a>
         </div>
       </section>
 
       <footer class="voice-footer">
         <p>公開可能な範囲で内容を要約し、匿名化した導入事例です。</p>
-        <a class="voice-nav__link" href="https://speed-ad.com/#top">ログイン前ページへ戻る</a>
+        <a class="voice-nav__link" href="../../../index.html#top">ログイン前ページへ戻る</a>
       </footer>
     </div>
   </main>

--- a/docs/画面設計/仕様/19_customer_voice_public_pages.md
+++ b/docs/画面設計/仕様/19_customer_voice_public_pages.md
@@ -42,14 +42,14 @@ last_reviewed: 2026-08-18
 3. 機能紹介後のティザーセクション: 2 事例の要約カード + `詳細を見る`
 4. フッター常設リンク: `導入事例`
 
-`導入事例` 関連導線の遷移先は `https://support.speed-ad.com/customer-voices/` とする。`無料ではじめる` は `https://speed-ad.com/?intent=signup#top` でSPEED ADトップページの新規アカウント作成モーダルへ接続する。
+本番の `導入事例` 関連導線は `https://support.speed-ad.com/customer-voices/` を正規URLとする。静的モックでは `05_support/customer-voices/` へ相対遷移し、導入事例内のログイン・新規登録導線もリポジトリルートの `index.html` へ戻すことで、モックサイト内で確認を完結させる。
 
 ### 3.2. ページ間導線
 
 - 一覧ページから各詳細ページへ遷移できること
 - 各詳細ページ下部に `他の事例を見る` を配置し、一覧へ戻れること
-- 一覧ページおよび詳細ページの主 CTA は `無料ではじめる` とし、遷移先は `https://speed-ad.com/?intent=signup#top` とする
-- 副 CTA は `ログインはこちら` とし、遷移先は `https://speed-ad.com/#top` とする
+- 静的モックの一覧ページおよび詳細ページの主 CTA は `無料ではじめる` とし、ルート `index.html?intent=signup#top` へ相対遷移する
+- 静的モックの副 CTA は `ログインはこちら` とし、ルート `index.html#top` へ相対遷移する
 
 ### 3.3. ログイン前トップ復帰時の挙動
 
@@ -200,7 +200,7 @@ last_reviewed: 2026-08-18
 
 ## 7. 確認項目
 
-- `index.html` の 3 導線から `https://support.speed-ad.com/customer-voices/` へ到達できること
+- `index.html` の導入事例導線からモック内の `05_support/customer-voices/` へ到達できること
 - 一覧ページの各カードから正しい詳細ページへ遷移できること
 - 一覧ページに 3 件が表示され、オリエンタルモーター株式会社様が先頭に表示されること
 - ログイン前トップの先頭ティザーがオリエンタルモーター株式会社様になり、事例要約が通常の説明文として表示されること

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
             <a class="site-top-header__nav-link" href="#features-title">機能</a>
             <a class="site-top-header__nav-link" href="#flow-title">流れ</a>
             <a class="site-top-header__nav-link" href="#capabilities">選ばれる理由</a>
-            <a class="site-top-header__nav-link" href="https://support.speed-ad.com/customer-voices/" target="_blank" rel="noopener noreferrer">導入事例</a>
+            <a class="site-top-header__nav-link" href="05_support/customer-voices/">導入事例</a>
             <a class="site-top-header__cta" href="?intent=signup#top" data-signup-trigger>無料ではじめる</a>
           </nav>
         </div>
@@ -528,7 +528,7 @@
             </div>
           </div>
         </div>
-        <a class="voice-teaser__link" href="https://support.speed-ad.com/customer-voices/" target="_blank" rel="noopener noreferrer">すべての声を見る <span aria-hidden="true">→</span></a>
+        <a class="voice-teaser__link" href="05_support/customer-voices/">すべての声を見る <span aria-hidden="true">→</span></a>
       </div>
     </section>
     </div>
@@ -632,7 +632,7 @@
     </div>
   </div>
 
-  <script src="js/login-front.js?v=20260818-oriental-copy-v2" defer></script>
+  <script src="js/login-front.js?v=20260818-mock-voice-routing-v1" defer></script>
   <script src="js/login-front-fullpage.js?v=20260602-tail-scroll-stop" defer></script>
   <!-- emblem-tools（開発者向け・?emblemtools=1 で起動）。撤去時はこの行とhead内のcssリンクを削除 -->
   <script src="js/emblem-tools.js" defer></script>

--- a/js/login-front.js
+++ b/js/login-front.js
@@ -179,10 +179,10 @@
   }
 
   function renderGenericCustomerVoiceTeaserCard() {
-    const detailUrl = 'https://support.speed-ad.com/customer-voices/';
+    const detailUrl = resolveAppPath('05_support/customer-voices/');
     const title = 'SPEED ADの活用事例を見る';
     return `
-      <a class="voice-teaser-card" href="${detailUrl}" target="_blank" rel="noopener noreferrer" style="--voice-accent: #2f80ed; --voice-accent-strong: #145cc7;" aria-label="${title}">
+      <a class="voice-teaser-card" href="${detailUrl}" style="--voice-accent: #2f80ed; --voice-accent-strong: #145cc7;" aria-label="${title}">
         <span class="voice-teaser-card__stripe" aria-hidden="true"></span>
         <div class="voice-teaser-card__media voice-teaser-card__media--skeleton" aria-hidden="true"></div>
         <div class="voice-teaser-card__body">
@@ -364,7 +364,7 @@
             : voice.listingSummary || voice.voicePageSummary || '';
           const author = voice.publicQuoteAuthor || voice.quote?.author || '';
           const descriptor = voice.organizationDescriptor || '';
-          const detailUrl = `https://support.speed-ad.com/customer-voices/${voice.slug || ''}/`;
+          const detailUrl = resolveAppPath(`05_support/customer-voices/${voice.slug || ''}/`);
           const accent = voice.accent || '#f3e2c1';
           const accentStrong = voice.accentStrong || accent;
           const features = Array.isArray(voice.teaserTags) ? voice.teaserTags.slice(0, 4) : (Array.isArray(voice.usedFeatures) ? voice.usedFeatures.slice(0, 4) : []);
@@ -377,7 +377,7 @@
             ? `<blockquote class="voice-teaser-card__quote">${escapeHtml(teaserText)}</blockquote>`
             : `<p class="voice-teaser-card__quote">${escapeHtml(teaserText)}</p>`;
           return `
-            <a class="voice-teaser-card" href="${escapeHtml(detailUrl)}" target="_blank" rel="noopener noreferrer" ${styleAttr} aria-label="${escapeHtml(title + ' の事例を読む')}">
+            <a class="voice-teaser-card" href="${escapeHtml(detailUrl)}" ${styleAttr} aria-label="${escapeHtml(title + ' の事例を読む')}">
               <span class="voice-teaser-card__stripe" aria-hidden="true"></span>
               <div class="voice-teaser-card__media" data-image-frame>
                 <img src="${escapeHtml(heroImage)}" alt="${escapeHtml(altText)}" loading="lazy">

--- a/tests/customer-voices.test.mjs
+++ b/tests/customer-voices.test.mjs
@@ -68,6 +68,32 @@ test('login teaser renders approved quotes and editorial summaries with differen
   assert.match(script, /hasApprovedQuote && author/);
 });
 
+test('mock customer voice navigation stays inside the local static site', async () => {
+  const loginHtml = await readFile('index.html', 'utf8');
+  const loginScript = await readFile('js/login-front.js', 'utf8');
+  const voicePages = await Promise.all([
+    readFile('05_support/customer-voices/index.html', 'utf8'),
+    readFile('05_support/customer-voices/oriental-motor/index.html', 'utf8'),
+    readFile('05_support/customer-voices/company-monitor/index.html', 'utf8'),
+    readFile('05_support/customer-voices/university-survey/index.html', 'utf8'),
+  ]);
+
+  assert.match(loginHtml, /href="05_support\/customer-voices\/"[^>]*>導入事例<\/a>/);
+  assert.match(loginHtml, /href="05_support\/customer-voices\/"[^>]*>すべての声を見る/);
+  assert.doesNotMatch(loginHtml, /<a\b[^>]*href="https:\/\/support\.speed-ad\.com\/customer-voices\//);
+  assert.match(loginScript, /resolveAppPath\('05_support\/customer-voices\/'\)/);
+  assert.match(loginScript, /resolveAppPath\(`05_support\/customer-voices\/\$\{voice\.slug \|\| ''\}\/`\)/);
+  assert.doesNotMatch(loginScript, /https:\/\/support\.speed-ad\.com\/customer-voices\//);
+
+  for (const html of voicePages) {
+    assert.doesNotMatch(html, /<a\b[^>]*href="https:\/\/(?:support\.)?speed-ad\.com\//);
+  }
+  assert.match(voicePages[0], /href="\.\.\/\.\.\/index\.html\?intent=signup#top"/);
+  for (const html of voicePages.slice(1)) {
+    assert.match(html, /href="\.\.\/\.\.\/\.\.\/index\.html#top"/);
+  }
+});
+
 test('customer voice specification records the named route and optional quote policy', async () => {
   const specification = await readFile('docs/画面設計/仕様/19_customer_voice_public_pages.md', 'utf8');
 


### PR DESCRIPTION
## 変更内容

- ログイントップの導入事例ナビと一覧リンクをモック内の相対URLへ変更
- 動的に生成される導入事例カードと読み込み失敗時カードもモック内へ遷移
- 導入事例一覧・各詳細ページのログイン／無料登録導線をモックトップへ統一
- モック内遷移の表示仕様と回帰テストを追加

## 動作確認

- `node --test tests/customer-voices.test.mjs tests/brand-assets.test.mjs`：10件成功
- `node --check js/login-front.js`：成功
- `git diff --check origin/main...HEAD`：問題なし
- Chromiumでトップ→一覧、トップ→事例詳細、詳細→無料登録を確認
- 全遷移が `127.0.0.1:8000` 内で完結し、登録モーダル表示・コンソールエラーなし

## 影響範囲

- ログイン前トップの導入事例導線
- 公開導入事例一覧・詳細ページのCTA
- 公開導入事例仕様とテスト
- canonical／OG、本番API、認証、保存処理への変更なし